### PR TITLE
chore(strict-migration): P04 batch A leaf utils typecheck via JSDoc

### DIFF
--- a/devlog/_plan/strict-migration/_gpt-pro-arbitration-p04-meta.md
+++ b/devlog/_plan/strict-migration/_gpt-pro-arbitration-p04-meta.md
@@ -1,0 +1,48 @@
+---
+phase: P04 (meta)
+gpt-pro-verdict: PASS — option B
+date: 2026-05-05
+sessionId: 01KQW97PPDWZQQBNGH34AJ2T7P
+conversationUrl: https://chatgpt.com/c/69fa00fe-8d68-83a3-8b17-4cc0f6022e5b
+---
+# P04 readiness — GPT Pro arbitration
+
+## Question
+
+See `/tmp/agbrowse-p04-meta.md`.
+
+## Pro answer (verbatim)
+
+I pick B.
+
+Physical rename is not valid in P04 under the approved invariants. Existing from './foo.mjs' specifiers name an exact relative ESM path; Node requires file extensions for relative/absolute ESM imports, and noEmit:true means TypeScript will not create a replacement .mjs file. That would violate runtime compatibility for bin/*.mjs and likely npm test, while also crossing the “no generated output/no dist” boundary. 
+Node.js
++1
+
+A is therefore out. Rewriting importers to ./foo.ts can work only by adopting a TypeScript runtime mechanism: current Node can run erasable .ts syntax without a flag in v22.18+ and required --experimental-strip-types on earlier v22 lines, while userland runners/loaders are another runtime choice. Either way, that is a P14 decision moved into P04; Node’s TS support also ignores tsconfig.json, so tsc --noEmit is not the runtime mechanism. 
+Node.js
++1
+
+C is out for the same reason, plus an emit conflict. .mts is TypeScript-native ESM; TypeScript documents that .mts emits to .mjs and .d.mts, but with noEmit:true there is no emitted .mjs, so C requires either Node/type-stripping at runtime or noEmit:false/generated files. That violates the P04 invariants and advances P14. 
+TypeScript
++1
+
+B preserves the invariants. Keep the .mjs files, import specifiers, bin/*.mjs, package.json#bin, and package.json#files manifest unchanged; add // @ts-check plus JSDoc to each P04 leaf. TypeScript supports JS type-checking via checkJs or per-file // @ts-check, so this gives selected-leaf checking without flipping global checkJs:false or changing runtime behavior. 
+TypeScript
++1
+
+The sibling .d.mts is the correct structural-type companion, not a runtime artifact. TypeScript treats .mjs/.d.mts as ESM and, for a runtime /mod.mjs lookup, can look for /mod.mts, then /mod.d.mts, then /mod.mjs; declaration files are type-only and do not produce JS output. Implementation note: ensure the checked .mjs leaf itself remains included in the TS program, because the .d.mts alone does not check the implementation body. 
+TypeScript
++1
+
+D has no conforming runtime escape hatch here. Any wrapper/dual-source alternative either still requires .ts/.mts execution, creates generated/duplicate runtime source outside the approved plan, or fails to increase implementation-body coverage. The round-4 PASS still holds when P04 is interpreted as “JSDoc + per-file @ts-check + sibling .d.mts for leaf .mjs files”, with true .mjs → .ts/.mts renames deferred to P14.
+
+VERDICT: B
+
+## Resolution
+
+- VERDICT: B — JSDoc + per-file `// @ts-check` + sibling `.d.mts` for cross-module structural types.
+- True `.mjs → .ts/.mts` rename deferred to **P14** (runtime/build decision).
+- Implementation note from Pro: ensure the checked `.mjs` leaf remains included in the TS program; `.d.mts` alone does NOT check the implementation body.
+- This preserves all hard invariants (P00.5 → P13) without violating no-dist/ and bin/*.mjs.
+- Round-4 PASS verdict remains intact under this interpretation.

--- a/devlog/_plan/strict-migration/phases/03-P04-leaf-utils-typecheck.md
+++ b/devlog/_plan/strict-migration/phases/03-P04-leaf-utils-typecheck.md
@@ -1,0 +1,84 @@
+# P04 — Leaf utils typecheck (VERDICT-B, batch A)
+
+## Decision binding
+
+GPT Pro arbitration (`devlog/_plan/strict-migration/_gpt-pro-arbitration-p04-meta.md`) returned
+**VERDICT B**: do **not** rename `.mjs` → `.ts`/`.mts` in P04. Keep `.mjs` filenames,
+keep `bin/*.mjs`, keep all import specifiers verbatim. Type-check `.mjs` source via
+JSDoc + per-file `// @ts-check`, with a sibling `tsconfig.checkjs.json` that flips
+`allowJs: true, checkJs: true` and includes only the leaves we have opted in. The
+hard rename to `.ts`/`.mts` is deferred to **P14**.
+
+This is the binding interpretation for P04 / P04b / P04c.
+
+## Why two tsconfigs
+
+Repo `tsconfig.json` has hard invariants we must not move:
+
+- `strict: true`, `noEmit: true`
+- `allowJs: false`, `checkJs: false`
+- `exclude: ["**/*.mjs", "**/*.js"]`, `include: [".ts only"]`
+
+If we flip `allowJs`/`checkJs` on `tsconfig.json` we expand the surface area of every
+typecheck across all `.mjs` and force the whole tree into the migration in one step,
+which Pro VERDICT-B explicitly rejects.
+
+Instead we ship a **second program**: `tsconfig.checkjs.json` extends the main
+config and turns on `allowJs`/`checkJs` only for explicit leaves. Each leaf is
+opted in via the `include` list. A new npm script `typecheck:checkjs` runs that
+program. The main `typecheck` script is unchanged and continues to ignore `.mjs`.
+
+This lets us migrate one leaf (or one tight cluster) per phase without leaking
+errors into the rest of the tree.
+
+## Batch A — first opt-in (this phase)
+
+Files included in `tsconfig.checkjs.json` for P04 batch A:
+
+| # | File | Notes |
+|---|------|-------|
+| 1 | `web-ai/types.mjs` | Pure JSDoc typedefs already, no runtime logic. |
+| 2 | `web-ai/constants.mjs` | `const`/`Object.freeze` only, no params. |
+| 3 | `web-ai/context-pack/types.mjs` | Pure JSDoc typedefs only. |
+| 4 | `web-ai/policy/default-policy.mjs` | `Object.freeze` literal default policy. |
+
+Each gets a `// @ts-check` directive at line 1 (defensive: makes the opt-in
+explicit per file even if `tsconfig.checkjs.json` is later refactored).
+
+Verified: `tsc --noEmit -p tsconfig.checkjs.json` → 0 errors.
+
+## Deferred to follow-up sub-phases
+
+| Phase | Files | Reason |
+|-------|-------|--------|
+| P04b | `web-ai/trace/redact.mjs`, `web-ai/trace/types.mjs`, `web-ai/eval/types.mjs`, `web-ai/cache-metrics.mjs`, `web-ai/churn-log.mjs` | Need JSDoc `@param` annotations to remove implicit-any from factory/sink params. |
+| P04c | `web-ai/observe-targets.mjs`, `web-ai/copy-markdown.mjs`, `web-ai/dom-hash.mjs` | Bodies execute inside `page.evaluate(...)` Playwright callbacks which reference DOM globals; need a scoped `lib: ["DOM"]` strategy or wrapped callback annotations. |
+
+Each sub-phase is its own PR and Pro round.
+
+## Gates run in this phase
+
+- `npm run typecheck` → green
+- `npm run typecheck:checkjs` → green (NEW)
+- `npm run smoke:bins` → green
+- `npm test` → green (473 passed, 12 skipped)
+- Manifest contract test (P02) — the four edited files were already shipped in
+  `package.json#files`; only their content changed (`// @ts-check` line) so the
+  manifest is unchanged.
+
+## Strategy doc amendment
+
+`devlog/_plan/strict-migration/01-strategy.md` says `allowJs: true, checkJs: false`
+in the `tsconfig.json` row of the Phase Table, which does not match HEAD. Per
+VERDICT-B we keep the main tsconfig as-is (`allowJs: false`, `.mjs` excluded)
+and use the side `tsconfig.checkjs.json` per phase. We will land a strategy
+amendment in a tiny follow-up patch (`_strategy-amendment-p04.md`) rather than
+rewrite `01-strategy.md` mid-stream.
+
+## Out of scope
+
+- No file renames.
+- No changes under `bin/`.
+- No changes to `package.json#bin` / `package.json#files`.
+- No changes to import specifiers.
+- No new runtime dependencies.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "check:strict-baseline": "node scripts/check-strict-baseline.mjs",
     "pack:dry": "npm pack --dry-run --json",
     "smoke:bins": "node scripts/smoke-bins.mjs",
-    "check:module-graph": "node scripts/check-module-graph.mjs"
+    "check:module-graph": "node scripts/check-module-graph.mjs",
+    "typecheck:checkjs": "tsc --noEmit -p tsconfig.checkjs.json"
   },
   "dependencies": {
     "fast-glob": "^3.3.3",

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": [
+    "types/**/*.d.ts",
+    "web-ai/types.mjs",
+    "web-ai/constants.mjs",
+    "web-ai/context-pack/types.mjs",
+    "web-ai/policy/default-policy.mjs"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}
+

--- a/web-ai/constants.mjs
+++ b/web-ai/constants.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 export const CACHE_SCHEMA_VERSION = 2;
 export const VALIDATION_THRESHOLD = 0.6;
 export const MAX_TRACE_STEPS = 200;

--- a/web-ai/context-pack/types.mjs
+++ b/web-ai/context-pack/types.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @typedef {'summary'|'json'|'full'} ContextDryRunMode
  * @typedef {'inline'|'upload'|'auto'|'none'} ContextTransportMode

--- a/web-ai/policy/default-policy.mjs
+++ b/web-ai/policy/default-policy.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 export const DEFAULT_WEB_AI_POLICY = Object.freeze({
     version: 1,
     allowedOrigins: [],

--- a/web-ai/types.mjs
+++ b/web-ai/types.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 export const WEB_AI_VENDOR = Object.freeze({
     CHATGPT: 'chatgpt',
     GEMINI: 'gemini',


### PR DESCRIPTION
## Summary

P04 **batch A** of the strict-migration: turn on TypeScript JSDoc checking for
4 type-only/constants leaves under `web-ai/`, via a new sibling
 .ts` rename (deferred to P14 per Pro
arbitration).

## Decision binding

GPT Pro arbitration (extended thinking, ~9 min round-trip) returned
**VERDICT B**: keep `.mjs` filenames + import specifiers verbatim, do
**not** rename to `.ts`/`.mts` in P04, type-check via per-file `// @ts-check`
+ JSDoc + side `tsconfig.checkjs.json` with `allowJs/checkJs: true` for
opted-in leaves only. Hard rename to `.ts`/`.mts` is deferred to **P14**.

Pro answer is recorded verbatim in
`devlog/_plan/strict-migration/_gpt-pro-arbitration-p04-meta.md`.

## Files (batch A)

| # | File | Errors with checkJs:true | Action |
|---|------|--------------------------|--------|
| 1 | `web-ai/types.mjs` | 0 | `// @ts-check` |
| 2 | `web-ai/constants.mjs` | 0 | `// @ts-check` |
| 3 | `web-ai/context-pack/types.mjs` | 0 | `// @ts-check` |
| 4 | `web-ai/policy/default-policy.mjs` | 0 | `// @ts-check` |

The other 8 leaves from the P03 candidate table need JSDoc additions and
are split into P04b (trace/eval/cache/churn) and P04c (DOM-touching
`page.evaluate`  each their own PR + Pro round.files) 

## Gates

 OK
 OK (NEW, 0 errors on the 4 files)
 OK
 473 passed, 12 skipped
- Manifest contract test ( only content of already-shipped files changedP02) 
  (single `// @ts-check` line each), so manifest is unchanged.

## Hard invariants preserved

- No file renames.
- `bin/*.mjs` untouched.
- `package.json#bin` / `package.json#files` unchanged.
- All import specifiers verbatim.
- Main `tsconfig.json` unchanged (`allowJs:false`, `**/*.mjs` excluded).
- `noEmit:true` everywhere.

## Follow-ups

- P04b: JSDoc-annotate trace/eval/cache/churn leaves to clear ~50 implicit-any
  errors, then opt them in.
- P04c: scope a `lib:["DOM"]` strategy for `page.evaluate` callbacks in
  observe-targets / copy-markdown / dom-hash, then opt them in.
- Strategy doc amendment (`_strategy-amendment-p04.md`) noting actual
  `tsconfig.json` values vs the table in `01-strategy.md`.
