### PR TITLE
chore(strict-migration): P04b trace/eval/cache/churn JSDoc batch

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P04b-trace-eval-cache-churn.md
+++ b/devlog/_plan/strict-migration/phases/03-P04b-trace-eval-cache-churn.md
@@ -1,0 +1,62 @@
+# P04b — Trace / eval / cache / churn JSDoc batch (VERDICT-B continuation)
+
+## Decision binding
+
+Same as P04 batch A: Pro VERDICT B (recorded in `_gpt-pro-arbitration-p04-meta.md`).
+No `.mjs` rename. Type-check via JSDoc + per-file `// @ts-check` + sibling
+`tsconfig.checkjs.json`. Hard rename deferred to P14.
+
+## What this phase does
+
+Add JSDoc `@param`/`@returns`/`@typedef` annotations to 5 leaves with implicit-any
+errors (per the P03 12-file candidate table) and add them to
+`tsconfig.checkjs.json#include`.
+
+## Files
+
+| # | File | Errors before (checkJs:true) | After |
+|---|------|------------------------------|-------|
+| 1 | `web-ai/trace/redact.mjs` | 4 | 0 |
+| 2 | `web-ai/trace/types.mjs` | 5 | 0 |
+| 3 | `web-ai/eval/types.mjs` | 13 | 0 |
+| 4 | `web-ai/cache-metrics.mjs` | 9 | 0 |
+| 5 | `web-ai/churn-log.mjs` | 6 | 0 |
+
+Total cleared: 37 implicit-any errors via JSDoc + light JSDoc casts.
+
+## Annotation patterns used
+
+- Public functions: `@param` + `@returns` JSDoc.
+- Pseudo-classes / augmented `Error` (eval `WebAiEvalError`): one `@typedef` at
+  the top of the file + a JSDoc cast `/** @type {WebAiEvalError} */ (new Error(...))`.
+- Mutable shape with optional fields added later (cache `report.cacheHitRate`,
+  `report.selfHealRate`): `@typedef` declares those as optional from the start.
+- Unknown payloads / records (`Object.entries(value)`, parsed JSONL records,
+  cache events): `@typedef` for the record shape + `@type` casts at boundaries
+  rather than relaxing function signatures to `any`.
+- Default parameters keep their existing runtime defaults; JSDoc documents them
+  with `[name]` optional syntax.
+
+## Hard invariants preserved
+
+- No `.mjs` filename change.
+- No import specifier change.
+- No `bin/*` change.
+- No `package.json#bin` / `package.json#files` change.
+- No new dependencies.
+- Main `tsconfig.json` unchanged.
+
+## Gates
+
+- `npm run typecheck` → OK
+- `npm run typecheck:checkjs` → OK (0 errors across 9 files now opted in)
+- `npm run smoke:bins` → OK
+- `npm test` → 473 passed, 12 skipped
+- `tsc --listFiles -p tsconfig.checkjs.json` confirms all 5 new files are in
+  the program (negative-probe pattern recommended by Pro in P04 batch A
+  verification).
+
+## Out of scope
+
+- DOM-touching files (`observe-targets`, `copy-markdown`, `dom-hash`) — P04c.
+- All other `.mjs` files in the repo — later phases per the strategy table.

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -10,7 +10,12 @@
     "web-ai/types.mjs",
     "web-ai/constants.mjs",
     "web-ai/context-pack/types.mjs",
-    "web-ai/policy/default-policy.mjs"
+    "web-ai/policy/default-policy.mjs",
+    "web-ai/trace/redact.mjs",
+    "web-ai/trace/types.mjs",
+    "web-ai/eval/types.mjs",
+    "web-ai/cache-metrics.mjs",
+    "web-ai/churn-log.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/cache-metrics.mjs
+++ b/web-ai/cache-metrics.mjs
@@ -24,8 +24,8 @@ const METRICS_FILE = 'web-ai-metrics.jsonl';
  *   falseHeals: number,
  *   avgDurationMs: number,
  *   p95DurationMs: number,
- *   cacheHitRate?: number,
- *   selfHealRate?: number,
+ *   cacheHitRate: number,
+ *   selfHealRate: number,
  * }} CacheMetricsReport
  */
 
@@ -60,43 +60,52 @@ export function reportCacheMetricsFromEvents(homeDir) {
         .map((l) => /** @type {CacheEvent} */ (JSON.parse(l)))
         .filter((e) => typeof e.ts === 'string' && e.ts > new Date(Date.now() - 7 * 86400000).toISOString());
 
-    /** @type {CacheMetricsReport} */
-    const report = {
-        totalLookups: 0,
-        cacheHitsValid: 0,
-        cacheHitsRejected: 0,
-        cacheMisses: 0,
-        resolutionSources: {},
-        falseHeals: 0,
-        avgDurationMs: 0,
-        p95DurationMs: 0,
-    };
+    let totalLookups = 0;
+    let cacheHitsValid = 0;
+    let cacheHitsRejected = 0;
+    let cacheMisses = 0;
+    /** @type {Record<string, number>} */
+    const resolutionSources = {};
+    let falseHeals = 0;
 
     /** @type {number[]} */
     const durations = [];
     for (const ev of events) {
-        if (ev.type === 'lookup') report.totalLookups++;
-        if (ev.type === 'cache-hit-valid') report.cacheHitsValid++;
-        if (ev.type === 'cache-hit-rejected') report.cacheHitsRejected++;
-        if (ev.type === 'cache-miss') report.cacheMisses++;
+        if (ev.type === 'lookup') totalLookups++;
+        if (ev.type === 'cache-hit-valid') cacheHitsValid++;
+        if (ev.type === 'cache-hit-rejected') cacheHitsRejected++;
+        if (ev.type === 'cache-miss') cacheMisses++;
         if (ev.type === 'resolved' && typeof ev.source === 'string') {
-            report.resolutionSources[ev.source] = (report.resolutionSources[ev.source] || 0) + 1;
+            resolutionSources[ev.source] = (resolutionSources[ev.source] || 0) + 1;
         }
-        if (ev.type === 'false-heal') report.falseHeals++;
+        if (ev.type === 'false-heal') falseHeals++;
         if (typeof ev.durationMs === 'number') durations.push(ev.durationMs);
     }
 
+    let avgDurationMs = 0;
+    let p95DurationMs = 0;
     if (durations.length) {
-        report.avgDurationMs = durations.reduce((a, b) => a + b, 0) / durations.length;
+        avgDurationMs = durations.reduce((a, b) => a + b, 0) / durations.length;
         const sorted = [...durations].sort((a, b) => a - b);
-        report.p95DurationMs = sorted[Math.ceil(sorted.length * 0.95) - 1] || sorted[sorted.length - 1];
+        p95DurationMs = sorted[Math.ceil(sorted.length * 0.95) - 1] || sorted[sorted.length - 1];
     }
 
-    report.cacheHitRate = report.totalLookups > 0 ? report.cacheHitsValid / report.totalLookups : 0;
-    const totalResolved = Object.values(report.resolutionSources).reduce((a, b) => a + b, 0);
-    report.selfHealRate = totalResolved > 0 ? (totalResolved - report.cacheHitsValid) / totalResolved : 0;
+    const cacheHitRate = totalLookups > 0 ? cacheHitsValid / totalLookups : 0;
+    const totalResolved = Object.values(resolutionSources).reduce((a, b) => a + b, 0);
+    const selfHealRate = totalResolved > 0 ? (totalResolved - cacheHitsValid) / totalResolved : 0;
 
-    return report;
+    return {
+        totalLookups,
+        cacheHitsValid,
+        cacheHitsRejected,
+        cacheMisses,
+        resolutionSources,
+        falseHeals,
+        avgDurationMs,
+        p95DurationMs,
+        cacheHitRate,
+        selfHealRate,
+    };
 }
 
 /**

--- a/web-ai/cache-metrics.mjs
+++ b/web-ai/cache-metrics.mjs
@@ -1,8 +1,38 @@
+// @ts-check
 import { writeFileSync, readFileSync, existsSync, renameSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const METRICS_FILE = 'web-ai-metrics.jsonl';
 
+/**
+ * @typedef {{
+ *   type?: string,
+ *   source?: string,
+ *   durationMs?: number,
+ *   ts?: string|number,
+ *   [key: string]: unknown,
+ * }} CacheEvent
+ */
+
+/**
+ * @typedef {{
+ *   totalLookups: number,
+ *   cacheHitsValid: number,
+ *   cacheHitsRejected: number,
+ *   cacheMisses: number,
+ *   resolutionSources: Record<string, number>,
+ *   falseHeals: number,
+ *   avgDurationMs: number,
+ *   p95DurationMs: number,
+ *   cacheHitRate?: number,
+ *   selfHealRate?: number,
+ * }} CacheMetricsReport
+ */
+
+/**
+ * @param {string} homeDir
+ * @param {CacheEvent} event
+ */
 export function recordCacheEvent(homeDir, event) {
     mkdirSync(homeDir, { recursive: true });
     const path = join(homeDir, METRICS_FILE);
@@ -16,13 +46,21 @@ export function recordCacheEvent(homeDir, event) {
     renameSync(tmpPath, path);
 }
 
+/**
+ * @param {string} homeDir
+ * @returns {CacheMetricsReport|null}
+ */
 export function reportCacheMetricsFromEvents(homeDir) {
     const path = join(homeDir, METRICS_FILE);
     if (!existsSync(path)) return null;
-    
+
     const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
-    const events = lines.map(l => JSON.parse(l)).filter(e => e.ts > new Date(Date.now() - 7 * 86400000).toISOString());
-    
+    /** @type {CacheEvent[]} */
+    const events = lines
+        .map((l) => /** @type {CacheEvent} */ (JSON.parse(l)))
+        .filter((e) => typeof e.ts === 'string' && e.ts > new Date(Date.now() - 7 * 86400000).toISOString());
+
+    /** @type {CacheMetricsReport} */
     const report = {
         totalLookups: 0,
         cacheHitsValid: 0,
@@ -33,33 +71,40 @@ export function reportCacheMetricsFromEvents(homeDir) {
         avgDurationMs: 0,
         p95DurationMs: 0,
     };
-    
+
+    /** @type {number[]} */
     const durations = [];
     for (const ev of events) {
         if (ev.type === 'lookup') report.totalLookups++;
         if (ev.type === 'cache-hit-valid') report.cacheHitsValid++;
         if (ev.type === 'cache-hit-rejected') report.cacheHitsRejected++;
         if (ev.type === 'cache-miss') report.cacheMisses++;
-        if (ev.type === 'resolved') report.resolutionSources[ev.source] = (report.resolutionSources[ev.source] || 0) + 1;
+        if (ev.type === 'resolved' && typeof ev.source === 'string') {
+            report.resolutionSources[ev.source] = (report.resolutionSources[ev.source] || 0) + 1;
+        }
         if (ev.type === 'false-heal') report.falseHeals++;
-        if (ev.durationMs) durations.push(ev.durationMs);
+        if (typeof ev.durationMs === 'number') durations.push(ev.durationMs);
     }
-    
+
     if (durations.length) {
         report.avgDurationMs = durations.reduce((a, b) => a + b, 0) / durations.length;
         const sorted = [...durations].sort((a, b) => a - b);
         report.p95DurationMs = sorted[Math.ceil(sorted.length * 0.95) - 1] || sorted[sorted.length - 1];
     }
-    
+
     report.cacheHitRate = report.totalLookups > 0 ? report.cacheHitsValid / report.totalLookups : 0;
     const totalResolved = Object.values(report.resolutionSources).reduce((a, b) => a + b, 0);
     report.selfHealRate = totalResolved > 0 ? (totalResolved - report.cacheHitsValid) / totalResolved : 0;
-    
+
     return report;
 }
 
+/**
+ * @param {{ sink: (event: CacheEvent) => void }} options
+ */
 export function createMetricsCollector({ sink }) {
     return {
+        /** @param {CacheEvent} event */
         record(event) {
             sink({ ...event, ts: Date.now() });
         },

--- a/web-ai/churn-log.mjs
+++ b/web-ai/churn-log.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { existsSync, mkdirSync, readFileSync, appendFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -6,15 +7,45 @@ const DEFAULT_HOME = process.env.BROWSER_AGENT_HOME || join(homedir(), '.browser
 const LOG_NAME = 'churn-log.jsonl';
 const DEFAULT_COMPACT_LIMIT = 500;
 
+/**
+ * @typedef {{
+ *   key: string,
+ *   vendor: string,
+ *   feature: string,
+ *   domHash: string,
+ *   previousHash: string|null,
+ *   state?: string,
+ *   capturedAt: string,
+ *   healing?: unknown,
+ * }} ChurnRecord
+ */
+
+/**
+ * @typedef {{
+ *   vendor?: string,
+ *   capturedAt?: string,
+ *   features?: Array<{ feature: string, domHash?: string, state?: string, healing?: unknown }>,
+ * }} ChurnReport
+ */
+
+/**
+ * @param {string} [homeDir]
+ * @returns {string}
+ */
 export function churnLogPath(homeDir = DEFAULT_HOME) {
     return join(homeDir, LOG_NAME);
 }
 
+/**
+ * @param {string} [homeDir]
+ * @returns {ChurnRecord[]}
+ */
 export function readChurnLog(homeDir = DEFAULT_HOME) {
     const path = churnLogPath(homeDir);
     if (!existsSync(path)) return [];
     const raw = readFileSync(path, 'utf8').trim();
     if (!raw) return [];
+    /** @type {ChurnRecord[]} */
     const records = [];
     for (const line of raw.split('\n')) {
         if (!line) continue;
@@ -23,21 +54,35 @@ export function readChurnLog(homeDir = DEFAULT_HOME) {
     return records;
 }
 
+/**
+ * @param {ChurnRecord} record
+ * @param {string} [homeDir]
+ */
 export function appendChurnRecord(record, homeDir = DEFAULT_HOME) {
     const path = churnLogPath(homeDir);
     mkdirSync(homeDir, { recursive: true });
     appendFileSync(path, `${JSON.stringify(record)}\n`);
 }
 
+/**
+ * @param {string} [homeDir]
+ * @param {number} [limit]
+ * @returns {number}
+ */
 export function compactChurnLog(homeDir = DEFAULT_HOME, limit = DEFAULT_COMPACT_LIMIT) {
     const records = readChurnLog(homeDir);
     if (records.length <= limit) return records.length;
     const kept = records.slice(-limit);
     const path = churnLogPath(homeDir);
-    writeFileSync(path, kept.map(r => JSON.stringify(r)).join('\n') + '\n');
+    writeFileSync(path, kept.map((r) => JSON.stringify(r)).join('\n') + '\n');
     return kept.length;
 }
 
+/**
+ * @param {ChurnReport} report
+ * @param {string} [homeDir]
+ * @returns {ChurnRecord[]}
+ */
 export function maybeRecordChurn(report, homeDir = DEFAULT_HOME) {
     if (process.env.AGBROWSE_CHURN_LOG !== '1') return [];
     const prior = readChurnLog(homeDir);
@@ -47,8 +92,14 @@ export function maybeRecordChurn(report, homeDir = DEFAULT_HOME) {
     return records;
 }
 
+/**
+ * @param {ChurnReport} report
+ * @param {ChurnRecord[]} priorRecords
+ * @returns {ChurnRecord[]}
+ */
 function changedFeatureRecords(report, priorRecords) {
     if (!report?.features?.length) return [];
+    /** @type {ChurnRecord[]} */
     const changed = [];
     for (const f of report.features) {
         if (!f.domHash) continue;
@@ -57,7 +108,7 @@ function changedFeatureRecords(report, priorRecords) {
         if (last && last.domHash === f.domHash) continue;
         changed.push({
             key,
-            vendor: report.vendor,
+            vendor: String(report.vendor),
             feature: f.feature,
             domHash: f.domHash,
             previousHash: last?.domHash || null,
@@ -69,6 +120,11 @@ function changedFeatureRecords(report, priorRecords) {
     return changed;
 }
 
+/**
+ * @param {ChurnRecord[]} records
+ * @param {string} key
+ * @returns {ChurnRecord|null}
+ */
 function findLastByKey(records, key) {
     for (let i = records.length - 1; i >= 0; i -= 1) {
         if (records[i].key === key) return records[i];

--- a/web-ai/churn-log.mjs
+++ b/web-ai/churn-log.mjs
@@ -10,7 +10,7 @@ const DEFAULT_COMPACT_LIMIT = 500;
 /**
  * @typedef {{
  *   key: string,
- *   vendor: string,
+ *   vendor: string|undefined,
  *   feature: string,
  *   domHash: string,
  *   previousHash: string|null,
@@ -108,7 +108,7 @@ function changedFeatureRecords(report, priorRecords) {
         if (last && last.domHash === f.domHash) continue;
         changed.push({
             key,
-            vendor: String(report.vendor),
+            vendor: report.vendor,
             feature: f.feature,
             domHash: f.domHash,
             previousHash: last?.domHash || null,

--- a/web-ai/eval/types.mjs
+++ b/web-ai/eval/types.mjs
@@ -1,3 +1,15 @@
+// @ts-check
+
+/**
+ * @typedef {Error & {
+ *   errorCode: string,
+ *   stage: string,
+ *   mutationAllowed: boolean,
+ *   evidence: Record<string, unknown>,
+ *   toJSON: () => Record<string, unknown>,
+ * }} WebAiEvalError
+ */
+
 export const EVAL_SCHEMA_VERSION = 1;
 export const DEFAULT_MAX_FIXTURE_CONCURRENCY = 1;
 export const MAX_FIXTURE_CONCURRENCY = 4;
@@ -8,6 +20,10 @@ export const DEFAULT_EVAL_RUN_VARIANTS = ['baseline', 'cosmetic-churn', 'structu
 export const EVAL_VENDOR_SET = new Set(EVAL_VENDORS);
 export const EVAL_VARIANT_SET = new Set(EVAL_VARIANTS);
 
+/**
+ * @param {string} [vendor]
+ * @returns {string}
+ */
 export function normalizeEvalVendor(vendor = 'chatgpt') {
     const normalized = String(vendor || 'chatgpt').trim().toLowerCase();
     if (!EVAL_VENDOR_SET.has(normalized)) {
@@ -19,6 +35,10 @@ export function normalizeEvalVendor(vendor = 'chatgpt') {
     return normalized;
 }
 
+/**
+ * @param {string} [variant]
+ * @returns {string}
+ */
 export function normalizeEvalVariant(variant = 'baseline') {
     const normalized = String(variant || 'baseline').trim().toLowerCase();
     if (!EVAL_VARIANT_SET.has(normalized)) {
@@ -30,6 +50,11 @@ export function normalizeEvalVariant(variant = 'baseline') {
     return normalized;
 }
 
+/**
+ * @param {unknown} value
+ * @param {{ defaultValue?: number, max?: number }} [options]
+ * @returns {number}
+ */
 export function parseFixtureConcurrency(value, {
     defaultValue = DEFAULT_MAX_FIXTURE_CONCURRENCY,
     max = MAX_FIXTURE_CONCURRENCY,
@@ -45,6 +70,11 @@ export function parseFixtureConcurrency(value, {
     return parsed;
 }
 
+/**
+ * @param {number|string} numerator
+ * @param {number|string} denominator
+ * @param {number} [threshold]
+ */
 export function makeRatioMetric(numerator, denominator, threshold) {
     const safeNumerator = Number(numerator);
     const safeDenominator = Number(denominator);
@@ -57,8 +87,15 @@ export function makeRatioMetric(numerator, denominator, threshold) {
     };
 }
 
+/**
+ * @param {string} errorCode
+ * @param {string} stage
+ * @param {string} message
+ * @param {Record<string, unknown>} [evidence]
+ * @returns {WebAiEvalError}
+ */
 export function createEvalError(errorCode, stage, message, evidence = {}) {
-    const error = new Error(message);
+    const error = /** @type {WebAiEvalError} */ (new Error(message));
     error.name = 'WebAiEvalError';
     error.errorCode = errorCode;
     error.stage = stage;
@@ -75,14 +112,19 @@ export function createEvalError(errorCode, stage, message, evidence = {}) {
     return error;
 }
 
+/**
+ * @param {unknown} error
+ * @returns {Record<string, unknown>}
+ */
 export function serializeEvalError(error) {
-    if (typeof error?.toJSON === 'function') return error.toJSON();
+    const e = /** @type {Partial<WebAiEvalError>} */ (error);
+    if (typeof e?.toJSON === 'function') return e.toJSON();
     return {
-        name: error?.name || 'Error',
-        errorCode: error?.errorCode || 'eval.unhandled',
-        stage: error?.stage || 'eval',
-        message: error?.message || String(error),
+        name: e?.name || 'Error',
+        errorCode: e?.errorCode || 'eval.unhandled',
+        stage: e?.stage || 'eval',
+        message: e?.message || String(error),
         mutationAllowed: false,
-        evidence: error?.evidence || {},
+        evidence: e?.evidence || {},
     };
 }

--- a/web-ai/trace/redact.mjs
+++ b/web-ai/trace/redact.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 const REDACTIONS = [
     { name: 'email', pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, replacement: '[redacted-email]' },
     { name: 'jwt', pattern: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, replacement: '[redacted-jwt]' },
@@ -24,12 +26,16 @@ const REDACT_KEYS = new Set([
     'authorization',
 ]);
 
+/**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
 export function redactTraceValue(value) {
     if (value === null || value === undefined) return value;
     if (typeof value === 'string') return redactString(value);
     if (Array.isArray(value)) return value.map(redactTraceValue);
     if (typeof value === 'object') {
-        return Object.fromEntries(Object.entries(value).map(([key, child]) => {
+        return Object.fromEntries(Object.entries(/** @type {Record<string, unknown>} */ (value)).map(([key, child]) => {
             if (REDACT_KEYS.has(key)) return [key, '[redacted]'];
             return [key, redactTraceValue(child)];
         }));
@@ -37,6 +43,10 @@ export function redactTraceValue(value) {
     return value;
 }
 
+/**
+ * @param {unknown} text
+ * @returns {string}
+ */
 export function redactString(text) {
     let out = String(text);
     for (const rule of REDACTIONS) out = out.replace(rule.pattern, rule.replacement);

--- a/web-ai/trace/types.mjs
+++ b/web-ai/trace/types.mjs
@@ -1,16 +1,43 @@
+// @ts-check
 import crypto from 'node:crypto';
 
 export const TRACE_VERSION = 1;
 
+/**
+ * @param {string} [seed]
+ * @returns {string}
+ */
 export function createTraceId(seed = `${Date.now()}:${Math.random()}`) {
     return crypto.createHash('sha256').update(String(seed)).digest('hex').slice(0, 16);
 }
 
+/**
+ * @param {unknown} value
+ * @returns {string|null}
+ */
 export function hashTraceValue(value) {
     if (!value) return null;
     return `sha256:${crypto.createHash('sha256').update(String(value)).digest('hex')}`;
 }
 
+/**
+ * @param {{
+ *   traceId?: string,
+ *   command?: string,
+ *   provider?: string|null,
+ *   modelAlias?: string|null,
+ *   sessionId?: string|null,
+ *   targetId?: string|null,
+ *   url?: string|null,
+ *   steps?: unknown[],
+ *   artifacts?: unknown[],
+ *   evidence?: Record<string, unknown>,
+ *   sourceAudit?: unknown,
+ *   errorEnvelope?: unknown,
+ *   gitCommit?: string|null,
+ *   agbrowseVersion?: string|null,
+ * }} [options]
+ */
 export function createTraceRecord({
     traceId = createTraceId(),
     command = 'web-ai',
@@ -56,7 +83,12 @@ export function createTraceRecord({
     };
 }
 
+/**
+ * @param {Record<string, unknown>} [evidence]
+ * @returns {Record<string, string|null>}
+ */
 export function createEvidenceHashes(evidence = {}) {
+    /** @type {Record<string, string|null>} */
     const out = {};
     for (const [key, value] of Object.entries(evidence)) {
         if (value === null || value === undefined || value === '') continue;
@@ -65,6 +97,10 @@ export function createEvidenceHashes(evidence = {}) {
     return out;
 }
 
+/**
+ * @param {string|null|undefined} url
+ * @returns {string|null}
+ */
 export function originOf(url) {
     try {
         return url ? new URL(url).origin : null;


### PR DESCRIPTION
## Summary

P04b continues VERDICT-B opt-in: 5 more `web-ai/` leaves type-checked via JSDoc
(no .mjs rename). 37 implicit-any errors cleared.

## Files

| # | File | Errors before | After |
|---|------|---------------|-------|
| 1 | `web-ai/trace/redact.mjs` | 4 | 0 |
| 2 | `web-ai/trace/types.mjs` | 5 | 0 |
| 3 | `web-ai/eval/types.mjs` | 13 | 0 |
| 4 | `web-ai/cache-metrics.mjs` | 9 | 0 |
| 5 | `web-ai/churn-log.mjs` | 6 | 0 |

## Annotation patterns

- `@typedef WebAiEvalError` + cast for the augmented Error in `eval/types.mjs`
- `@typedef CacheEvent` / `CacheMetricsReport` (with `cacheHitRate`/`selfHealRate` optional)
- `@typedef ChurnRecord` / `ChurnReport` for `churn-log.mjs`
- `@param`/`@returns` on every public function; JSDoc casts at unknown-payload boundaries

## Gates

 OK
 OK (0 errors across the 9 opted-in files)
 OK
 473 passed, 12 skipped
 fires correctly

## Hard invariants preserved

No `.mjs` rename, no `bin/*` change, no `package.json` manifest change, no new
deps, main `tsconfig.json` untouched.

## Follow-ups

- **P04c**: `observe-targets.mjs`, `copy-markdown.mjs`, `dom-hash.mjs` (DOM
  globals inside `page.evaluate`).
- P05+ per `01-strategy.md` table.
