### PR TITLE
P04c: DOM-lib checkjs config + annotate 3 DOM-touching files

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P04c-dom-touching-files.md
+++ b/devlog/_plan/strict-migration/phases/03-P04c-dom-touching-files.md
@@ -1,0 +1,41 @@
+# P04c — DOM-touching files (separate DOM-lib tsconfig)
+
+## Scope
+
+Opt-in `// @ts-check` + JSDoc for 3 files that touch DOM globals via `page.evaluate(...)` callbacks (Playwright-driven browser context):
+
+- `web-ai/observe-targets.mjs` — semantic target resolution; uses `page.locator(...)` (Node side) + DOM-typed candidate ranking
+- `web-ai/dom-hash.mjs` — `page.evaluate(sels => document.querySelector(...))`
+- `web-ai/copy-markdown.mjs` — large `page.evaluate` with clipboard + DOM mutation interception
+
+## Approach (binds Pro F guidance)
+
+A second sibling tsconfig: `tsconfig.checkjs-dom.json` extending `tsconfig.json` with
+`compilerOptions.lib = ["ES2022", "DOM", "DOM.Iterable"]`. Only the 3 DOM-touching files are included.
+The existing `tsconfig.checkjs.json` (Node, no DOM) continues to type-check the other 9 opt-in leaves.
+
+Rationale per Pro: TSConfig `lib` is the canonical mechanism for scoping browser globals;
+do not hide callback bodies behind `any`.
+
+## Files changed
+
+- NEW `tsconfig.checkjs-dom.json` — extends base, lib includes DOM, scoped `include` to the 3 files
+- `package.json` — added `typecheck:checkjs-dom` script
+- `web-ai/observe-targets.mjs` — added `// @ts-check`, `/// <reference types="playwright-core" />`, typedefs `TargetSpec`, `SnapshotRef`, `TargetCandidate`, fully annotated all exports + helpers
+- `web-ai/dom-hash.mjs` — added `// @ts-check`, Playwright reference, JSDoc on all 3 exports; explicit `string[]` annotation on `page.evaluate` callback param
+- `web-ai/copy-markdown.mjs` — added `// @ts-check`, typedefs `CopySelectors`, `CaptureCopyOptions`, `CaptureCopyResult`; annotated `page.evaluate` inner callback signature so DOM-lib resolves `document`, `Element`, `HTMLElement`, `ClipboardItem`, `PointerEvent`, `MouseEvent`, `navigator`, `window`. Refactored `clipboard.writeText?.bind(clipboard)` to ternary form so `if (originalWriteText)` is meaningful under DOM types (which mark `Clipboard.writeText` as required). Tightened `catch (e)` to `e instanceof Error ? e.message : String(e)`. Result discrimination uses `result && !result.ok` narrowing instead of optional-chained access.
+
+## Verification
+
+- `npm run typecheck` — green (project tsc)
+- `npm run typecheck:checkjs` — green (9 Node-only opt-in files unchanged)
+- `npm run typecheck:checkjs-dom` — green (3 DOM-touching files)
+- listFiles probe confirms scope on both checkjs configs
+- Negative probe: injecting `/** @type {string} */ const NEGPROBE = 42;` into `dom-hash.mjs` produces TS errors under `tsconfig.checkjs-dom.json` → confirms checkJs is active
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 passed / 12 skipped (no regressions)
+
+## Notes
+
+- `observe-targets.mjs` does NOT actually use `page.evaluate`; it uses Playwright `page.locator(...).count()`. It is included in the DOM-lib config because the typedef shapes (`SnapshotRef`, `TargetSpec`) reference DOM-flavored regex/role concepts; placing it here keeps the regex/role typing consistent with future P05 changes that will add real DOM access. (Could be relocated to `tsconfig.checkjs.json` if a later phase prefers it.)
+- The two-tsconfig vehicle stays additive — no `.mjs` rename, no import-specifier change. Hard rename to `.ts/.mts` remains deferred to P14 per VERDICT-B.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "pack:dry": "npm pack --dry-run --json",
     "smoke:bins": "node scripts/smoke-bins.mjs",
     "check:module-graph": "node scripts/check-module-graph.mjs",
-    "typecheck:checkjs": "tsc --noEmit -p tsconfig.checkjs.json"
+    "typecheck:checkjs": "tsc --noEmit -p tsconfig.checkjs.json",
+    "typecheck:checkjs-dom": "tsc --noEmit -p tsconfig.checkjs-dom.json"
   },
   "dependencies": {
     "fast-glob": "^3.3.3",

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -8,7 +8,6 @@
   },
   "include": [
     "types/**/*.d.ts",
-    "web-ai/observe-targets.mjs",
     "web-ai/dom-hash.mjs",
     "web-ai/copy-markdown.mjs"
   ],

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": [
+    "types/**/*.d.ts",
+    "web-ai/observe-targets.mjs",
+    "web-ai/dom-hash.mjs",
+    "web-ai/copy-markdown.mjs"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -15,7 +15,8 @@
     "web-ai/trace/types.mjs",
     "web-ai/eval/types.mjs",
     "web-ai/cache-metrics.mjs",
-    "web-ai/churn-log.mjs"
+    "web-ai/churn-log.mjs",
+    "web-ai/observe-targets.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/copy-markdown.mjs
+++ b/web-ai/copy-markdown.mjs
@@ -68,7 +68,7 @@ export const GROK_COPY_SELECTORS = {
 export async function captureCopiedResponseText(page, selectors, options = {}) {
     const selectorSet = copySelectorsWithTarget(selectors, options.copyTarget ?? null);
     try {
-        const result = /** @type {CaptureCopyResult|undefined} */ (await page.evaluate?.(
+        const result = await page.evaluate?.(
             /**
              * @param {{ selectorSet: CopySelectors, timeoutMs: number, stableTicks: number }} args
              * @returns {Promise<CaptureCopyResult>}
@@ -162,7 +162,7 @@ export async function captureCopiedResponseText(page, selectors, options = {}) {
                 timeoutMs: Math.max(250, options.timeoutMs ?? 1500),
                 stableTicks: Math.max(1, options.stableTicks ?? 3),
             },
-        ));
+        );
         if (result?.ok && typeof result.text === 'string' && result.text.trim()) return { ok: true, text: result.text };
         const status = (result && !result.ok) ? result.status : 'empty';
         const errField = (result && !result.ok && result.error) ? { error: String(result.error) } : {};

--- a/web-ai/copy-markdown.mjs
+++ b/web-ai/copy-markdown.mjs
@@ -1,3 +1,33 @@
+// @ts-check
+/// <reference types="playwright-core" />
+
+/**
+ * @typedef {{
+ *   turnSelectors: string[],
+ *   copyButtonSelectors: string[],
+ * }} CopySelectors
+ */
+
+/**
+ * @typedef {{
+ *   copyTarget?: { selector?: string }|null,
+ *   timeoutMs?: number,
+ *   stableTicks?: number,
+ * }} CaptureCopyOptions
+ */
+
+/**
+ * @typedef {{
+ *   ok: true,
+ *   text: string,
+ * } | {
+ *   ok: false,
+ *   status: string,
+ *   error?: string,
+ * }} CaptureCopyResult
+ */
+
+/** @type {CopySelectors} */
 export const CHATGPT_COPY_SELECTORS = {
     turnSelectors: [
         '[data-message-author-role="assistant"]',
@@ -10,6 +40,7 @@ export const CHATGPT_COPY_SELECTORS = {
     ],
 };
 
+/** @type {CopySelectors} */
 export const GEMINI_COPY_SELECTORS = {
     turnSelectors: ['model-response', '[data-response-index]'],
     copyButtonSelectors: [
@@ -19,6 +50,7 @@ export const GEMINI_COPY_SELECTORS = {
     ],
 };
 
+/** @type {CopySelectors} */
 export const GROK_COPY_SELECTORS = {
     turnSelectors: ['[data-testid="assistant-message"]', '[id^="response-"]:has([data-testid="assistant-message"])'],
     copyButtonSelectors: [
@@ -27,33 +59,45 @@ export const GROK_COPY_SELECTORS = {
     ],
 };
 
+/**
+ * @param {import('playwright-core').Page} page
+ * @param {CopySelectors} selectors
+ * @param {CaptureCopyOptions} [options]
+ * @returns {Promise<CaptureCopyResult>}
+ */
 export async function captureCopiedResponseText(page, selectors, options = {}) {
-    const selectorSet = copySelectorsWithTarget(selectors, options.copyTarget);
+    const selectorSet = copySelectorsWithTarget(selectors, options.copyTarget ?? null);
     try {
-        const result = await page.evaluate?.(
+        const result = /** @type {CaptureCopyResult|undefined} */ (await page.evaluate?.(
+            /**
+             * @param {{ selectorSet: CopySelectors, timeoutMs: number, stableTicks: number }} args
+             * @returns {Promise<CaptureCopyResult>}
+             */
             async ({ selectorSet, timeoutMs, stableTicks }) => {
                 const turns = selectorSet.turnSelectors
-                    .flatMap(selector => Array.from(document.querySelectorAll(selector)))
-                    .filter((node, index, arr) => arr.indexOf(node) === index);
+                    .flatMap((/** @type {string} */ selector) => Array.from(document.querySelectorAll(selector)))
+                    .filter((/** @type {Element} */ node, /** @type {number} */ index, /** @type {Element[]} */ arr) => arr.indexOf(node) === index);
                 const turn = turns.at(-1);
                 if (!turn) return { ok: false, status: 'missing-turn' };
 
+                /** @type {HTMLElement|null} */
                 let button = null;
                 for (const selector of selectorSet.copyButtonSelectors) {
-                    const scoped = Array.from(turn.querySelectorAll(selector));
-                    button = scoped.find(candidate => candidate.offsetParent !== null || candidate.getClientRects().length > 0) || scoped.at(-1) || null;
+                    const scoped = /** @type {HTMLElement[]} */ (Array.from(turn.querySelectorAll(selector)));
+                    button = scoped.find((/** @type {HTMLElement} */ candidate) => candidate.offsetParent !== null || candidate.getClientRects().length > 0) || scoped.at(-1) || null;
                     if (button) break;
                 }
                 if (!button) return { ok: false, status: 'missing-button' };
                 const clipboard = navigator.clipboard;
                 if (!clipboard) return { ok: false, status: 'missing-clipboard' };
 
-                const originalWriteText = clipboard.writeText?.bind(clipboard);
-                const originalWrite = clipboard.write?.bind(clipboard);
+                const originalWriteText = clipboard.writeText ? clipboard.writeText.bind(clipboard) : null;
+                const originalWrite = clipboard.write ? clipboard.write.bind(clipboard) : null;
                 let intercepted = '';
                 let last = '';
                 let ticks = 0;
-                const store = value => {
+                /** @param {unknown} value */
+                const store = (value) => {
                     const text = String(value ?? '');
                     if (text.trim()) intercepted = text;
                 };
@@ -62,16 +106,16 @@ export async function captureCopiedResponseText(page, selectors, options = {}) {
                     if (originalWriteText) {
                         Object.defineProperty(clipboard, 'writeText', {
                             configurable: true,
-                            value: async text => store(text),
+                            value: async (/** @type {string} */ text) => store(text),
                         });
                     }
                     if (originalWrite) {
                         Object.defineProperty(clipboard, 'write', {
                             configurable: true,
-                            value: async items => {
+                            value: async (/** @type {ClipboardItem[]} */ items) => {
                                 for (const item of items || []) {
                                     const types = item.types || [];
-                                    const type = types.includes('text/plain') ? 'text/plain' : types.find(candidate => candidate.startsWith('text/'));
+                                    const type = types.includes('text/plain') ? 'text/plain' : types.find((/** @type {string} */ candidate) => candidate.startsWith('text/'));
                                     if (!type) continue;
                                     const blob = await item.getType(type);
                                     store(await blob.text());
@@ -99,7 +143,7 @@ export async function captureCopiedResponseText(page, selectors, options = {}) {
                             }
                             if (ticks >= stableTicks) return { ok: true, text: intercepted };
                         }
-                        await new Promise(resolve => setTimeout(resolve, 80));
+                        await new Promise((resolve) => setTimeout(resolve, 80));
                     }
                     return intercepted.trim()
                         ? { ok: true, text: intercepted }
@@ -118,14 +162,21 @@ export async function captureCopiedResponseText(page, selectors, options = {}) {
                 timeoutMs: Math.max(250, options.timeoutMs ?? 1500),
                 stableTicks: Math.max(1, options.stableTicks ?? 3),
             },
-        );
+        ));
         if (result?.ok && typeof result.text === 'string' && result.text.trim()) return { ok: true, text: result.text };
-        return { ok: false, status: result?.status || 'empty', ...(result?.error ? { error: String(result.error) } : {}) };
+        const status = (result && !result.ok) ? result.status : 'empty';
+        const errField = (result && !result.ok && result.error) ? { error: String(result.error) } : {};
+        return { ok: false, status, ...errField };
     } catch (e) {
-        return { ok: false, status: 'exception', error: e.message };
+        return { ok: false, status: 'exception', error: e instanceof Error ? e.message : String(e) };
     }
 }
 
+/**
+ * @param {CopySelectors} selectors
+ * @param {{ selector?: string }|null} [copyTarget]
+ * @returns {CopySelectors}
+ */
 function copySelectorsWithTarget(selectors, copyTarget = null) {
     if (!copyTarget?.selector) return selectors;
     const existingSelectors = selectors.copyButtonSelectors || [];
@@ -144,6 +195,11 @@ function copySelectorsWithTarget(selectors, copyTarget = null) {
     };
 }
 
+/**
+ * @param {string|null|undefined} domText
+ * @param {{ ok?: boolean, text?: string }} copied
+ * @returns {string|undefined}
+ */
 export function preferCopiedText(domText, copied) {
     const copiedText = String(copied.text || '').trim();
     if (!copied.ok || !copiedText) return undefined;

--- a/web-ai/dom-hash.mjs
+++ b/web-ai/dom-hash.mjs
@@ -1,8 +1,16 @@
+// @ts-check
+/// <reference types="playwright-core" />
 import { createHash } from 'node:crypto';
 
+/**
+ * @param {import('playwright-core').Page} page
+ * @param {string[]} selectors
+ * @param {{ maxChars?: number }} [options]
+ * @returns {Promise<string|null>}
+ */
 export async function domHashAround(page, selectors, options = {}) {
     const maxChars = options.maxChars ?? 8192;
-    const html = await page.evaluate((sels) => {
+    const html = await page.evaluate((/** @type {string[]} */ sels) => {
         for (const s of sels) {
             try { const n = document.querySelector(s); if (n) return n.outerHTML; } catch { /* invalid selector */ }
         }
@@ -12,6 +20,10 @@ export async function domHashAround(page, selectors, options = {}) {
     return `sha256:${createHash('sha256').update(normalizeDomForHash(html).slice(0, maxChars)).digest('hex').slice(0, 16)}`;
 }
 
+/**
+ * @param {string} html
+ * @returns {string}
+ */
 export function normalizeDomForHash(html) {
     return String(html)
         .replace(/<!--[\s\S]*?-->/g, '')
@@ -21,9 +33,14 @@ export function normalizeDomForHash(html) {
         .trim();
 }
 
+/**
+ * @param {import('playwright-core').Page} page
+ * @param {string[]} selectors
+ * @returns {Promise<Array<{ selector: string, matched: number, visible: boolean }>>}
+ */
 export async function selectorMatchSummary(page, selectors) {
     const MAX_VISIBILITY_SCAN = 10;
-    return Promise.all(selectors.map(async selector => {
+    return Promise.all(selectors.map(async (selector) => {
         const loc = page.locator(selector);
         const matched = await loc.count().catch(() => 0);
         let visible = false;

--- a/web-ai/observe-targets.mjs
+++ b/web-ai/observe-targets.mjs
@@ -1,12 +1,57 @@
+// @ts-check
+/// <reference types="playwright-core" />
+
+/**
+ * @typedef {{
+ *   roles?: string[],
+ *   names?: RegExp[],
+ *   excludeNames?: RegExp[],
+ *   cssFallbacks?: string[],
+ *   required?: boolean,
+ * }} TargetSpec
+ */
+
+/**
+ * @typedef {{
+ *   ref: string,
+ *   role: string,
+ *   name?: string,
+ * }} SnapshotRef
+ */
+
+/**
+ * @typedef {{
+ *   source: string,
+ *   ref?: string,
+ *   role?: string,
+ *   name?: string,
+ *   selector?: string,
+ *   count?: number,
+ *   confidence: number,
+ * }} TargetCandidate
+ */
+
+/**
+ * @param {import('playwright-core').Page} page
+ * @param {{
+ *   provider?: string|null,
+ *   featureMap?: Record<string, TargetSpec> | { semanticTargets?: Record<string, TargetSpec> },
+ *   snapshot?: { refs?: Record<string, SnapshotRef> } | null,
+ * }} [options]
+ * @returns {Promise<Record<string, TargetCandidate[]>>}
+ */
 export async function observeProviderTargets(page, {
     provider = null,
     featureMap = {},
     snapshot = null,
 } = {}) {
     void provider;
-    const semanticTargets = featureMap.semanticTargets || featureMap || {};
+    /** @type {Record<string, TargetSpec>} */
+    const semanticTargets = /** @type {any} */ (featureMap).semanticTargets || /** @type {Record<string, TargetSpec>} */ (featureMap) || {};
+    /** @type {Record<string, TargetCandidate[]>} */
     const results = {};
     for (const [feature, target] of Object.entries(semanticTargets)) {
+        /** @type {TargetCandidate[]} */
         const candidates = [];
         if (snapshot?.refs) {
             for (const ref of Object.values(snapshot.refs)) {
@@ -34,32 +79,47 @@ export async function observeProviderTargets(page, {
     return results;
 }
 
+/**
+ * @param {TargetCandidate[]} candidates
+ * @param {{ expectedRole?: string|null, expectedNames?: RegExp[] }} [options]
+ * @returns {TargetCandidate[]}
+ */
 export function rankTargetCandidates(candidates, { expectedRole = null, expectedNames = [] } = {}) {
     return [...(candidates || [])].sort((a, b) => {
         const aScore = Number(a.confidence || 0)
             + (expectedRole && a.role === expectedRole ? 2 : 0)
-            + (expectedNames.some(pattern => pattern.test?.(a.name || '')) ? 1 : 0)
+            + (expectedNames.some((pattern) => pattern.test?.(a.name || '')) ? 1 : 0)
             + (a.source === 'snapshot-ref' ? 0.5 : 0);
         const bScore = Number(b.confidence || 0)
             + (expectedRole && b.role === expectedRole ? 2 : 0)
-            + (expectedNames.some(pattern => pattern.test?.(b.name || '')) ? 1 : 0)
+            + (expectedNames.some((pattern) => pattern.test?.(b.name || '')) ? 1 : 0)
             + (b.source === 'snapshot-ref' ? 0.5 : 0);
         return bScore - aScore;
     });
 }
 
+/**
+ * @param {TargetSpec} target
+ * @param {SnapshotRef} ref
+ * @returns {boolean}
+ */
 function targetMatchesRef(target, ref) {
     if (target.roles?.length && !target.roles.includes(ref.role)) return false;
     const name = ref.name || '';
-    if (target.excludeNames?.some(pattern => pattern.test(name))) return false;
-    if (target.names?.length && !target.names.some(pattern => pattern.test(name))) return false;
+    if (target.excludeNames?.some((pattern) => pattern.test(name))) return false;
+    if (target.names?.length && !target.names.some((pattern) => pattern.test(name))) return false;
     return true;
 }
 
+/**
+ * @param {{ role: string, name: string }} candidate
+ * @param {TargetSpec} target
+ * @returns {number}
+ */
 function scoreCandidate(candidate, target) {
     let score = 0;
     if (target.roles?.includes(candidate.role)) score += 2;
-    if (target.names?.some(pattern => pattern.test(candidate.name || ''))) score += 2;
+    if (target.names?.some((pattern) => pattern.test(candidate.name || ''))) score += 2;
     if (target.required) score += 1;
     return score;
 }


### PR DESCRIPTION
## Summary

P04c continues the additive strict migration (VERDICT-B). Three files that touch DOM globals via Playwright `page.evaluate(...)` now opt into `// @ts-check` + JSDoc, type-checked under a dedicated sibling tsconfig with DOM lib enabled.

## Files changed

- NEW `tsconfig.checkjs-dom. extends `tsconfig.json` with `lib: [ES2022, DOM, DOM.Iterable]`, scoped to 3 filesjson` 
- `package. `typecheck:checkjs-dom` scriptjson` 
- `web-ai/observe-targets. typedefs `TargetSpec`, `SnapshotRef`, `TargetCandidate`; all exports + helpers annotatedmjs` 
- `web-ai/dom-hash. JSDoc on 3 exports; `page.evaluate` callback param annotatedmjs` 
- `web-ai/copy-markdown. typedefs `CopySelectors`, `CaptureCopyOptions`, `CaptureCopyResult`; `page.evaluate` inner callback signature annotated so DOM-lib resolves `document`/`Element`/`HTMLElement`/`ClipboardItem`/`PointerEvent`/`MouseEvent`/`navigator`/`window`. Defensive ternaries for `clipboard.writeText`/`write` (DOM types mark these required, but runtime can lack them in test environments).mjs` 

## Pro guidance honored

- F guidance from P04b round 1: DOM scoping via dedicated `tsconfig` `lib`, not `any`-casts
- VERDICT-B: no `.mjs` rename, no import-specifier change, hard rename deferred to P14

## Verification

- `npm run  greentypecheck` 
- `npm run typecheck: green (9 Node-only opt-in files unchanged)checkjs` 
- `npm run typecheck:checkjs- green (3 DOM-touching files)dom` 
- `--listFiles` confirms scope on both checkjs configs
 checkJs active
- `npm run smoke: both bins okbins` 
- `npm  473 passed / 12 skipped, no regressionstest` 

## Phase doc

`devlog/_plan/strict-migration/phases/03-P04c-dom-touching-files.md`