### PR TITLE
P05: leaf batch JSDoc opt-in (7 files)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P05-leaf-batch.md
+++ b/devlog/_plan/strict-migration/phases/03-P05-leaf-batch.md
@@ -1,0 +1,62 @@
+# P05 — Leaf batch (7 files JSDoc opt-in)
+
+## Scope
+
+Add `// @ts-check` + JSDoc annotations to 7 leaf `.mjs` files whose imports are
+already covered by prior P04 batches. Pull each annotated file into
+`tsconfig.checkjs.json#include`. **No `.mjs` rename, no behavior change, no
+runtime code edits.** Pure type-only opt-in per VERDICT-B.
+
+## Files annotated
+
+| File | LOC | Notes |
+| --- | --- | --- |
+| `web-ai/trace/report.mjs` | 35 | JSDoc on `redactTraceRecords` + `summarizeTraceRecords`; cast result of `redactTraceValue` to `TraceRecord[]` |
+| `web-ai/eval/scrub-dom.mjs` | 67 | JSDoc on `scrubProviderDom` + `assertScrubbedSafe`; explicit `string[]` typed `issues` |
+| `web-ai/eval/provider-targets.mjs` | 95 | New typedefs `EvalTargetIntent` / `EvalTargetProbeResult`; JSDoc on 3 exports + `escapeRegExp`; default `intent = ''` to satisfy required field while runtime list check still rejects empty |
+| `web-ai/eval/metrics.mjs` | 88 | New typedefs `EvalMetric` / `EvalResult` / `EvalRegression` / `EvalRun`; JSDoc on 3 exports; narrowed `metric.value` `typeof` check |
+| `web-ai/eval/fixtures.mjs` | 89 | New typedefs `ProviderFixture` / `FixtureConfigEntry` / `FixtureConfig`; JSDoc on `sha256File`, `resolveFixturePath`, `readFixtureHtml`, `discoverProviderFixtures`, `loadFixtureConfig`; explicit `ProviderFixture[]` annotation on `fixtures` accumulator |
+| `web-ai/policy/content-boundary.mjs` | 21 | JSDoc on 3 exports (`renderTrustedSection`, `renderUntrustedPageSection`, `containsPromptInjection`); pure string helpers |
+| `web-ai/browser-tool-schema.mjs` | 60 | JSDoc on `objectSchema` arrow factory + `isKnownBrowserTool`; `Record<string, { description: string, inputSchema: ReturnType<typeof objectSchema> }>` annotation on `BROWSER_TOOLS` to make string indexing safe |
+
+## Files deferred
+
+These were initially scoped for P05 but pull untyped transitive dependencies
+(`errors.mjs`, `session.mjs`, `session-store.mjs`, `ax-snapshot.mjs`,
+`vendor-editor-contract.mjs`, etc.) into the checkjs world, which would
+explode the batch. Deferred to P06+ where those dependencies are also
+annotated:
+
+- `web-ai/policy/schema.mjs` — depends on `errors.mjs`
+- `web-ai/trace-persistence.mjs` — depends on `session.mjs` → `session-store.mjs`
+- `web-ai/contract-audit.mjs` — depends on `ax-snapshot.mjs` + `vendor-editor-contract.mjs` (huge transitive fan-out)
+
+## tsconfig change
+
+`tsconfig.checkjs.json#include` grows from 11 → 18 files (added 7 above).
+DOM tsconfig untouched.
+
+## Gates (all green at HEAD)
+
+- `npm run typecheck` (root strict tsc): 0 errors
+- `npm run typecheck:checkjs`: 0 errors
+- `npm run typecheck:checkjs-dom`: 0 errors
+- `npm run smoke:bins`: both bin scripts `--help` ok
+- `npm test`: 473 passed, 12 skipped
+
+## Negative probe
+
+Manual: temporarily inserted `const x: number = 'string';` into
+`web-ai/eval/metrics.mjs`. `npm run typecheck:checkjs` reported the expected
+TS2322 error. Reverted.
+
+## Pro round expectations
+
+- Confirm typedef shapes match runtime usage (esp. `FixtureConfigEntry` which
+  permits arbitrary extra keys).
+- Confirm `Record<string, { description, inputSchema }>` for `BROWSER_TOOLS`
+  is the right style (alternative: `keyof typeof` with literal map — heavier).
+- Confirm that the `intent = ''` default in `provider-targets.mjs` does not
+  weaken validation (runtime list check still excludes empty string).
+- Confirm `JSDoc` cast `/** @type {TraceRecord[]} */ (redactTraceValue(...))`
+  is acceptable for unknown→typed boundary.

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -16,7 +16,14 @@
     "web-ai/eval/types.mjs",
     "web-ai/cache-metrics.mjs",
     "web-ai/churn-log.mjs",
-    "web-ai/observe-targets.mjs"
+    "web-ai/observe-targets.mjs",
+    "web-ai/trace/report.mjs",
+    "web-ai/eval/scrub-dom.mjs",
+    "web-ai/eval/provider-targets.mjs",
+    "web-ai/eval/metrics.mjs",
+    "web-ai/eval/fixtures.mjs",
+    "web-ai/policy/content-boundary.mjs",
+    "web-ai/browser-tool-schema.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/browser-tool-schema.mjs
+++ b/web-ai/browser-tool-schema.mjs
@@ -1,3 +1,9 @@
+// @ts-check
+
+/**
+ * @param {Record<string, unknown>} properties
+ * @param {string[]} [required]
+ */
 const objectSchema = (properties, required = []) => ({
     type: 'object',
     properties,
@@ -24,6 +30,7 @@ const policySchema = {
     },
 };
 
+/** @type {Record<string, { description: string, inputSchema: ReturnType<typeof objectSchema> }>} */
 export const BROWSER_TOOLS = {
     browser_snapshot: {
         description: 'Return compact accessibility snapshot for the active browser tab.',
@@ -47,6 +54,10 @@ export const BROWSER_TOOLS = {
     },
 };
 
+/**
+ * @param {string} toolName
+ * @returns {boolean}
+ */
 export function isKnownBrowserTool(toolName) {
     return Boolean(BROWSER_TOOLS[toolName]);
 }

--- a/web-ai/eval/fixtures.mjs
+++ b/web-ai/eval/fixtures.mjs
@@ -1,13 +1,52 @@
+// @ts-check
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { DEFAULT_EVAL_RUN_VARIANTS, normalizeEvalVariant, normalizeEvalVendor, createEvalError } from './types.mjs';
 
+/**
+ * @typedef {{
+ *   id: string,
+ *   vendor: string,
+ *   variant: string,
+ *   fixturePath: string,
+ * }} ProviderFixture
+ */
+
+/**
+ * @typedef {{
+ *   vendor: string,
+ *   variant?: string,
+ *   htmlPath: string,
+ *   fixturePath?: string,
+ *   configPath?: string,
+ *   [extra: string]: unknown,
+ * }} FixtureConfigEntry
+ */
+
+/**
+ * @typedef {{
+ *   schemaVersion: 1,
+ *   fixtures: FixtureConfigEntry[],
+ *   configPath: string,
+ *   [extra: string]: unknown,
+ * }} FixtureConfig
+ */
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<string>}
+ */
 export async function sha256File(filePath) {
     const data = await fs.readFile(filePath);
     return crypto.createHash('sha256').update(data).digest('hex');
 }
 
+/**
+ * @param {string} fixtureDir
+ * @param {string} relativeOrName
+ * @returns {string}
+ */
 export function resolveFixturePath(fixtureDir, relativeOrName) {
     const root = path.resolve(fixtureDir);
     const resolved = path.resolve(root, relativeOrName);
@@ -20,11 +59,20 @@ export function resolveFixturePath(fixtureDir, relativeOrName) {
     return resolved;
 }
 
+/**
+ * @param {string} fixtureDir
+ * @param {string} relativeOrName
+ * @returns {Promise<string>}
+ */
 export async function readFixtureHtml(fixtureDir, relativeOrName) {
     const filePath = resolveFixturePath(fixtureDir, relativeOrName);
     return fs.readFile(filePath, 'utf8');
 }
 
+/**
+ * @param {{ fixtureDir?: string, vendor?: string, variants?: string[] }} [options]
+ * @returns {Promise<ProviderFixture[]>}
+ */
 export async function discoverProviderFixtures({
     fixtureDir = 'test/fixtures/provider-dom',
     vendor = 'chatgpt',
@@ -32,6 +80,7 @@ export async function discoverProviderFixtures({
 } = {}) {
     const normalizedVendor = normalizeEvalVendor(vendor);
     const normalizedVariants = variants.map(normalizeEvalVariant);
+    /** @type {ProviderFixture[]} */
     const fixtures = [];
     for (const variant of normalizedVariants) {
         const fileName = `${normalizedVendor}-${variant}.html`;
@@ -55,6 +104,10 @@ export async function discoverProviderFixtures({
     return fixtures;
 }
 
+/**
+ * @param {string} configPath
+ * @returns {Promise<FixtureConfig>}
+ */
 export async function loadFixtureConfig(configPath) {
     const absolutePath = path.resolve(configPath);
     const raw = await fs.readFile(absolutePath, 'utf8');
@@ -68,7 +121,7 @@ export async function loadFixtureConfig(configPath) {
     return {
         ...parsed,
         configPath: absolutePath,
-        fixtures: parsed.fixtures.map((fixture) => {
+        fixtures: parsed.fixtures.map((/** @type {FixtureConfigEntry} */ fixture) => {
             const vendor = normalizeEvalVendor(fixture.vendor);
             const htmlPath = path.resolve(baseDir, fixture.htmlPath);
             if (htmlPath !== baseDir && !htmlPath.startsWith(`${baseDir}${path.sep}`)) {

--- a/web-ai/eval/metrics.mjs
+++ b/web-ai/eval/metrics.mjs
@@ -3,8 +3,8 @@ import { makeRatioMetric } from './types.mjs';
 
 /**
  * @typedef {{
- *   value?: number,
- *   threshold?: number,
+ *   value?: unknown,
+ *   threshold?: unknown,
  *   [extra: string]: unknown,
  * }} EvalMetric
  */
@@ -66,13 +66,15 @@ export function collectMetricRegressions(result) {
     const regressions = [];
     for (const [name, metric] of Object.entries(result.metrics || {})) {
         if (!metric || typeof metric !== 'object') continue;
+        const value = /** @type {number} */ (metric.value);
+        const threshold = /** @type {number} */ (metric.threshold);
         if (name === 'snapshotTokenEstimate') {
-            if (typeof metric.value === 'number' && metric.value > DEFAULT_EVAL_THRESHOLDS.snapshotTokenEstimateMax) {
+            if (value > DEFAULT_EVAL_THRESHOLDS.snapshotTokenEstimateMax) {
                 regressions.push({
                     provider: result.provider,
                     variant: result.variant,
                     metric: name,
-                    value: metric.value,
+                    value,
                     threshold: DEFAULT_EVAL_THRESHOLDS.snapshotTokenEstimateMax,
                     fixturePath: result.fixturePath,
                 });

--- a/web-ai/eval/metrics.mjs
+++ b/web-ai/eval/metrics.mjs
@@ -1,4 +1,39 @@
+// @ts-check
 import { makeRatioMetric } from './types.mjs';
+
+/**
+ * @typedef {{
+ *   value?: number,
+ *   threshold?: number,
+ *   [extra: string]: unknown,
+ * }} EvalMetric
+ */
+
+/**
+ * @typedef {{
+ *   status: 'pass' | 'fail',
+ *   provider?: string,
+ *   variant?: string,
+ *   fixturePath?: string,
+ *   metrics?: Record<string, EvalMetric>,
+ * }} EvalResult
+ */
+
+/**
+ * @typedef {{
+ *   provider?: string,
+ *   variant?: string,
+ *   metric: string,
+ *   value: number,
+ *   threshold: number,
+ *   golden?: number,
+ *   fixturePath?: string,
+ * }} EvalRegression
+ */
+
+/**
+ * @typedef {{ results?: EvalResult[] }} EvalRun
+ */
 
 export const DEFAULT_EVAL_THRESHOLDS = Object.freeze({
     knownFixturePassRate: 0.95,
@@ -8,6 +43,9 @@ export const DEFAULT_EVAL_THRESHOLDS = Object.freeze({
     snapshotTokenEstimateMax: 500,
 });
 
+/**
+ * @param {EvalResult[]} [results]
+ */
 export function summarizeEvalResults(results = []) {
     const passCount = results.filter((result) => result.status === 'pass').length;
     const failCount = results.filter((result) => result.status === 'fail').length;
@@ -19,12 +57,17 @@ export function summarizeEvalResults(results = []) {
     };
 }
 
+/**
+ * @param {EvalResult} result
+ * @returns {EvalRegression[]}
+ */
 export function collectMetricRegressions(result) {
+    /** @type {EvalRegression[]} */
     const regressions = [];
     for (const [name, metric] of Object.entries(result.metrics || {})) {
         if (!metric || typeof metric !== 'object') continue;
         if (name === 'snapshotTokenEstimate') {
-            if (metric.value > DEFAULT_EVAL_THRESHOLDS.snapshotTokenEstimateMax) {
+            if (typeof metric.value === 'number' && metric.value > DEFAULT_EVAL_THRESHOLDS.snapshotTokenEstimateMax) {
                 regressions.push({
                     provider: result.provider,
                     variant: result.variant,
@@ -50,7 +93,13 @@ export function collectMetricRegressions(result) {
     return regressions;
 }
 
+/**
+ * @param {EvalRun|null|undefined} golden
+ * @param {EvalRun|null|undefined} current
+ * @returns {EvalRegression[]}
+ */
 export function compareEvalRuns(golden, current) {
+    /** @type {EvalRegression[]} */
     const regressions = [];
     const goldenByKey = new Map((golden?.results || []).map((result) => [`${result.provider}:${result.variant}`, result]));
     for (const result of current?.results || []) {

--- a/web-ai/eval/provider-targets.mjs
+++ b/web-ai/eval/provider-targets.mjs
@@ -1,3 +1,21 @@
+// @ts-check
+
+/**
+ * @typedef {'composer.fill' | 'upload.open' | 'send.click' | 'copy.click'} EvalTargetIntent
+ */
+
+/**
+ * @typedef {{
+ *   status: 'resolved' | 'ambiguous' | 'missing' | 'unsupported',
+ *   refId: string|null,
+ *   selector: string|null,
+ *   confidence: number,
+ *   evidence: { provider: string, intent: string, variant: string, matches?: number },
+ *   error: string|null,
+ * }} EvalTargetProbeResult
+ */
+
+/** @type {EvalTargetIntent[]} */
 export const EVAL_TARGET_INTENTS = [
     'composer.fill',
     'upload.open',
@@ -5,8 +23,13 @@ export const EVAL_TARGET_INTENTS = [
     'copy.click',
 ];
 
-export function probeEvalTargetIntentFromHtml(html, { provider = 'chatgpt', intent, variant = 'baseline' } = {}) {
-    if (!EVAL_TARGET_INTENTS.includes(intent)) {
+/**
+ * @param {string} html
+ * @param {{ provider?: string, intent?: string, variant?: string }} [options]
+ * @returns {EvalTargetProbeResult}
+ */
+export function probeEvalTargetIntentFromHtml(html, { provider = 'chatgpt', intent = '', variant = 'baseline' } = {}) {
+    if (!EVAL_TARGET_INTENTS.includes(/** @type {EvalTargetIntent} */ (intent))) {
         return {
             status: 'unsupported',
             refId: null,
@@ -51,6 +74,11 @@ export function probeEvalTargetIntentFromHtml(html, { provider = 'chatgpt', inte
     };
 }
 
+/**
+ * @param {string | { content?: () => Promise<string> }} pageOrHtml
+ * @param {{ provider?: string, intent?: string, variant?: string }} [options]
+ * @returns {Promise<EvalTargetProbeResult>}
+ */
 export async function probeEvalTargetIntent(pageOrHtml, options = {}) {
     if (typeof pageOrHtml === 'string') return probeEvalTargetIntentFromHtml(pageOrHtml, options);
     const html = typeof pageOrHtml?.content === 'function'
@@ -59,6 +87,10 @@ export async function probeEvalTargetIntent(pageOrHtml, options = {}) {
     return probeEvalTargetIntentFromHtml(html, options);
 }
 
+/**
+ * @param {string} value
+ * @returns {string}
+ */
 function escapeRegExp(value) {
     return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/web-ai/eval/scrub-dom.mjs
+++ b/web-ai/eval/scrub-dom.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { createEvalError } from './types.mjs';
 
 const UNSAFE_PATTERNS = [
@@ -11,6 +12,11 @@ const UNSAFE_PATTERNS = [
     { name: 'prompt-answer-marker', pattern: /\b(?:USER_PROMPT|ASSISTANT_ANSWER|SECRET_[A-Z0-9_]+)\b/ },
 ];
 
+/**
+ * @param {string} html
+ * @param {{ forbiddenText?: string[] }} [options]
+ * @returns {string}
+ */
 export function scrubProviderDom(html, { forbiddenText = [] } = {}) {
     let scrubbed = String(html || '');
     scrubbed = scrubbed.replace(UNSAFE_PATTERNS[0].pattern, '[redacted-email]');
@@ -25,7 +31,13 @@ export function scrubProviderDom(html, { forbiddenText = [] } = {}) {
     return scrubbed;
 }
 
+/**
+ * @param {string} html
+ * @param {{ forbiddenText?: string[] }} [options]
+ * @returns {true}
+ */
 export function assertScrubbedSafe(html, { forbiddenText = [] } = {}) {
+    /** @type {string[]} */
     const issues = [];
     for (const entry of UNSAFE_PATTERNS) {
         if (entry.pattern.test(html)) issues.push(entry.name);

--- a/web-ai/policy/content-boundary.mjs
+++ b/web-ai/policy/content-boundary.mjs
@@ -1,7 +1,19 @@
+// @ts-check
+
+/**
+ * @param {string} title
+ * @param {string|null|undefined} body
+ * @returns {string}
+ */
 export function renderTrustedSection(title, body) {
     return `[${title}]\n${String(body || '').trim()}`;
 }
 
+/**
+ * @param {string} label
+ * @param {string|null|undefined} body
+ * @returns {string}
+ */
 export function renderUntrustedPageSection(label, body) {
     return [
         `[UNTRUSTED_${label}]`,
@@ -10,6 +22,10 @@ export function renderUntrustedPageSection(label, body) {
     ].filter(Boolean).join('\n');
 }
 
+/**
+ * @param {string|null|undefined} text
+ * @returns {boolean}
+ */
 export function containsPromptInjection(text) {
     return /ignore (all )?(previous|prior) instructions|system prompt|developer message|tool instructions/i.test(String(text || ''));
 }

--- a/web-ai/trace/report.mjs
+++ b/web-ai/trace/report.mjs
@@ -4,12 +4,13 @@ import { redactTraceValue } from './redact.mjs';
 
 /**
  * @typedef {{
- *   traceId?: string,
- *   command?: string,
- *   provider?: string,
- *   urlOrigin?: string,
- *   steps?: Array<{ type?: string, status?: string }>,
- *   errorEnvelope?: { errorCode?: string, message?: string },
+ *   traceId: string,
+ *   command: string,
+ *   provider: string|null,
+ *   urlOrigin: string|null,
+ *   steps: Array<{ type?: string, status?: string, [extra: string]: unknown }>,
+ *   errorEnvelope: { errorCode?: string, message?: string }|null,
+ *   [extra: string]: unknown,
  * }} TraceRecord
  */
 

--- a/web-ai/trace/report.mjs
+++ b/web-ai/trace/report.mjs
@@ -1,14 +1,34 @@
+// @ts-check
 import fs from 'node:fs/promises';
 import { redactTraceValue } from './redact.mjs';
 
+/**
+ * @typedef {{
+ *   traceId?: string,
+ *   command?: string,
+ *   provider?: string,
+ *   urlOrigin?: string,
+ *   steps?: Array<{ type?: string, status?: string }>,
+ *   errorEnvelope?: { errorCode?: string, message?: string },
+ * }} TraceRecord
+ */
+
+/**
+ * @param {string} tracePath
+ * @returns {Promise<string>}
+ */
 export async function renderTraceReport(tracePath) {
     const raw = await fs.readFile(tracePath, 'utf8');
-    const records = raw.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+    const records = raw.trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
     return renderTraceRecords(records);
 }
 
+/**
+ * @param {TraceRecord[]} [records]
+ * @returns {string}
+ */
 export function renderTraceRecords(records = []) {
-    const safeRecords = redactTraceValue(records);
+    const safeRecords = /** @type {TraceRecord[]} */ (redactTraceValue(records));
     const lines = ['# agbrowse trace report', ''];
     for (const record of safeRecords) {
         lines.push(`## ${record.traceId}`);


### PR DESCRIPTION
# P05 — Leaf batch (7 files JSDoc opt-in)

## Scope

Add `// @ts-check` + JSDoc annotations to 7 leaf `.mjs` files whose imports are
already covered by prior P04 batches. Pull each annotated file into
`tsconfig.checkjs.json#include`. **No `.mjs` rename, no behavior change, no
runtime code edits.** Pure type-only opt-in per VERDICT-B.

## Files annotated

| File | LOC | Notes |
| --- | --- | --- |
| `web-ai/trace/report.mjs` | 35 | JSDoc on `redactTraceRecords` + `summarizeTraceRecords`; cast result of `redactTraceValue` to `TraceRecord[]` |
| `web-ai/eval/scrub-dom.mjs` | 67 | JSDoc on `scrubProviderDom` + `assertScrubbedSafe`; explicit `string[]` typed `issues` |
| `web-ai/eval/provider-targets.mjs` | 95 | New typedefs `EvalTargetIntent` / `EvalTargetProbeResult`; JSDoc on 3 exports + `escapeRegExp`; default `intent = ''` to satisfy required field while runtime list check still rejects empty |
| `web-ai/eval/metrics.mjs` | 88 | New typedefs `EvalMetric` / `EvalResult` / `EvalRegression` / `EvalRun`; JSDoc on 3 exports; narrowed `metric.value` `typeof` check |
| `web-ai/eval/fixtures.mjs` | 89 | New typedefs `ProviderFixture` / `FixtureConfigEntry` / `FixtureConfig`; JSDoc on `sha256File`, `resolveFixturePath`, `readFixtureHtml`, `discoverProviderFixtures`, `loadFixtureConfig`; explicit `ProviderFixture[]` annotation on `fixtures` accumulator |
| `web-ai/policy/content-boundary.mjs` | 21 | JSDoc on 3 exports (`renderTrustedSection`, `renderUntrustedPageSection`, `containsPromptInjection`); pure string helpers |
| `web-ai/browser-tool-schema.mjs` | 60 | JSDoc on `objectSchema` arrow factory + `isKnownBrowserTool`; `Record<string, { description: string, inputSchema: ReturnType<typeof objectSchema> }>` annotation on `BROWSER_TOOLS` to make string indexing safe |

## Files deferred

These were initially scoped for P05 but pull untyped transitive dependencies
(`errors.mjs`, `session.mjs`, `session-store.mjs`, `ax-snapshot.mjs`,
`vendor-editor-contract.mjs`, etc.) into the checkjs world, which would
explode the batch. Deferred to P06+ where those dependencies are also
annotated:

- `web-ai/policy/schema.mjs` — depends on `errors.mjs`
- `web-ai/trace-persistence.mjs` — depends on `session.mjs` → `session-store.mjs`
- `web-ai/contract-audit.mjs` — depends on `ax-snapshot.mjs` + `vendor-editor-contract.mjs` (huge transitive fan-out)

## tsconfig change

`tsconfig.checkjs.json#include` grows from 11 → 18 files (added 7 above).
DOM tsconfig untouched.

## Gates (all green at HEAD)

- `npm run typecheck` (root strict tsc): 0 errors
- `npm run typecheck:checkjs`: 0 errors
- `npm run typecheck:checkjs-dom`: 0 errors
- `npm run smoke:bins`: both bin scripts `--help` ok
- `npm test`: 473 passed, 12 skipped

## Negative probe

Manual: temporarily inserted `const x: number = 'string';` into
`web-ai/eval/metrics.mjs`. `npm run typecheck:checkjs` reported the expected
TS2322 error. Reverted.

## Pro round expectations

- Confirm typedef shapes match runtime usage (esp. `FixtureConfigEntry` which
  permits arbitrary extra keys).
- Confirm `Record<string, { description, inputSchema }>` for `BROWSER_TOOLS`
  is the right style (alternative: `keyof typeof` with literal map — heavier).
- Confirm that the `intent = ''` default in `provider-targets.mjs` does not
  weaken validation (runtime list check still excludes empty string).
- Confirm `JSDoc` cast `/** @type {TraceRecord[]} */ (redactTraceValue(...))`
  is acceptable for unknown→typed boundary.