### PR TITLE
P07: leaf runtime JSDoc opt-in (8 files)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P07-leaf-runtime.md
+++ b/devlog/_plan/strict-migration/phases/03-P07-leaf-runtime.md
@@ -1,0 +1,42 @@
+# P07 — Leaf Runtime Helpers (JSDoc opt-in, 8 files)
+
+## Scope
+
+Extend `tsconfig.checkjs.json` opt-in coverage by 8 leaf-runtime utility modules. No `.mjs` rename, no behavior change, no new deps. Pure annotation + sibling tsconfig include.
+
+## Files (8)
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `web-ai/mcp-state.mjs` | 34 | `McpSnapshot`/`McpState` typedefs |
+| `web-ai/policy/enforce.mjs` | 45 | `PolicyAction` typedef; reuses imported `WebAiPolicy` |
+| `web-ai/trace/writer.mjs` | 51 | `TraceWriteInput` typedef matching `createTraceRecord` shape |
+| `web-ai/action-trace.mjs` | 57 | `TraceContext.record()` / `setSnapshotHashBefore()` method types |
+| `web-ai/capability.mjs` | 85 | `CapabilityRow.evidence: unknown`; err cast pattern |
+| `web-ai/answer-artifact.mjs` | 85 | generic `withAnswerArtifact<R>` via `@template R` |
+| `web-ai/ref-registry.mjs` | 87 | `RefRegistry` mutable shape; `unknown` page param |
+| `web-ai/tool-schema.mjs` | 113 | `ToolDefinition` typedef; `Record<...>` casts on spread |
+
+Total checked files in tsconfig.checkjs.json: 23 → **31** (verified by `--listFiles`).
+
+## Pro-honored patterns
+
+- No runtime-changing JS. Pre-existing `... || 0`, `String(x)`, `(err)?.message` semantics preserved.
+- Where typedefs would narrow (literal-typed object spreads), use explicit typedef + `Record<string, ToolDefinition>` assertion on import — never widen by mutation.
+- `errorEnvelope: unknown` and `command?: string` (no `null`) match the canonical `createTraceRecord` signature in `web-ai/trace/types.mjs`. Writer typedef now defers to that contract instead of redefining a looser one.
+- `allToolSchemas` uses an inline `(name) => mapper(name)` closure to avoid `(string, number, string[])` arity bleed-through from `Array#map`.
+
+## Gates (all green)
+
+- `npx tsc --noEmit -p tsconfig.checkjs.json --listFiles` → 31 .mjs entries
+- `npm run typecheck` ✓
+- `npm run typecheck:checkjs-dom` ✓
+- `npm run smoke:bins` ✓
+- `npm test` → 473 passed, 12 skipped (no regression)
+- Negative probe: replacing `@returns {boolean}` on `isKnownMcpTool` with `{number}` triggers TS2322 → restored.
+
+## Out of scope
+
+- Any rename `.mjs → .ts/.mts` (deferred to P14).
+- DOM-touching code (`web-ai/snapshot/*`, `chatgpt-composer.mjs`, etc.) — those need `tsconfig.checkjs-dom.json` track.
+- Larger session/cli orchestration (P08+).

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -28,7 +28,15 @@
     "web-ai/policy/schema.mjs",
     "web-ai/session-store.mjs",
     "web-ai/session.mjs",
-    "web-ai/trace-persistence.mjs"
+    "web-ai/trace-persistence.mjs",
+    "web-ai/mcp-state.mjs",
+    "web-ai/policy/enforce.mjs",
+    "web-ai/trace/writer.mjs",
+    "web-ai/action-trace.mjs",
+    "web-ai/capability.mjs",
+    "web-ai/answer-artifact.mjs",
+    "web-ai/ref-registry.mjs",
+    "web-ai/tool-schema.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/action-trace.mjs
+++ b/web-ai/action-trace.mjs
@@ -1,13 +1,40 @@
+// @ts-check
 import { randomUUID } from 'node:crypto';
+
+/**
+ * @typedef {{
+ *   stepId?: string,
+ *   ts?: string,
+ *   status?: string,
+ *   target?: { resolution?: string, source?: string, [k: string]: unknown },
+ *   [extra: string]: unknown,
+ * }} TraceStep
+ */
+
+/**
+ * @typedef {{
+ *   sessionId: string|null,
+ *   snapshotHashBefore: string|null,
+ *   steps: TraceStep[],
+ *   record(step: TraceStep): void,
+ *   setSnapshotHashBefore(hash: string|null): void,
+ * }} TraceContext
+ */
 
 const MAX_TRACE_STEPS = 200;
 
+/**
+ * @param {string|null} sessionId
+ * @returns {TraceContext}
+ */
 export function createTraceContext(sessionId) {
+    /** @type {TraceStep[]} */
     const steps = [];
     return {
         sessionId,
         snapshotHashBefore: null,
         steps,
+        /** @param {TraceStep} step */
         record(step) {
             if (steps.length >= MAX_TRACE_STEPS) return;
             steps.push({
@@ -16,29 +43,46 @@ export function createTraceContext(sessionId) {
                 ...step,
             });
         },
+        /** @param {string|null} hash */
         setSnapshotHashBefore(hash) {
             this.snapshotHashBefore = hash;
         },
     };
 }
 
+/**
+ * @param {TraceContext|null|undefined} ctx
+ * @param {TraceStep} step
+ */
 export function recordTraceStep(ctx, step) {
     if (!ctx) return;
     ctx.record(step);
 }
 
+/**
+ * @param {TraceContext|null|undefined} ctx
+ * @returns {TraceStep[]}
+ */
 export function getSessionTrace(ctx) {
     if (!ctx) return [];
     return [...ctx.steps];
 }
 
+/**
+ * @param {TraceContext|null|undefined} ctx
+ */
 export function summarizeTrace(ctx) {
     if (!ctx) return null;
     return summarizeTraceSteps(ctx.sessionId, ctx.steps);
 }
 
+/**
+ * @param {string|null} sessionId
+ * @param {TraceStep[]} [steps]
+ */
 export function summarizeTraceSteps(sessionId, steps = []) {
     if (!steps.length) return null;
+    /** @type {Set<string>} */
     const sources = new Set();
     let errors = 0;
     for (const step of steps) {

--- a/web-ai/answer-artifact.mjs
+++ b/web-ai/answer-artifact.mjs
@@ -1,5 +1,41 @@
+// @ts-check
+
+/**
+ * @typedef {{
+ *   provider?: string,
+ *   sessionId?: string|null,
+ *   conversationUrl?: string|null,
+ *   capturedBy?: string,
+ *   captureMethod?: string,
+ *   markdown?: string,
+ *   text?: string,
+ *   exactnessScore?: number|string,
+ *   responseStableMs?: number|string|null,
+ *   warnings?: unknown[],
+ *   [extra: string]: unknown,
+ * }} AnswerArtifactInput
+ */
+
+/**
+ * @typedef {{
+ *   provider: string,
+ *   sessionId: string|null,
+ *   conversationUrl: string|null,
+ *   capturedBy: string,
+ *   markdown: string,
+ *   text: string,
+ *   exactnessScore: number,
+ *   responseStableMs: number|null,
+ *   warnings: string[],
+ * }} AnswerArtifact
+ */
+
 const CAPTURE_METHODS = new Set(['copy-button', 'dom-fallback', 'clipboard', 'manual', 'unknown']);
 
+/**
+ * @param {AnswerArtifactInput} [input]
+ * @returns {AnswerArtifact}
+ */
 export function createAnswerArtifact(input = {}) {
     const capturedBy = normalizeCaptureMethod(input.capturedBy || input.captureMethod);
     const markdown = normalizeText(input.markdown);
@@ -22,6 +58,11 @@ export function createAnswerArtifact(input = {}) {
     };
 }
 
+/**
+ * @param {Record<string, any>} [result]
+ * @param {Record<string, any>} [context]
+ * @returns {AnswerArtifact}
+ */
 export function artifactFromPollResult(result = {}, context = {}) {
     const capturedBy = result.capturedBy
         || result.captureMethod
@@ -40,7 +81,13 @@ export function artifactFromPollResult(result = {}, context = {}) {
     });
 }
 
-export function withAnswerArtifact(result = {}, context = {}) {
+/**
+ * @template {Record<string, any>} R
+ * @param {R} [result]
+ * @param {Record<string, any>} [context]
+ * @returns {R & { answerArtifact?: AnswerArtifact }}
+ */
+export function withAnswerArtifact(result = /** @type {R} */ ({}), context = {}) {
     if (result.answerArtifact) return result;
     if (!result.answerText && !result.markdown && !result.answerMarkdown && !result.text) return result;
     return {
@@ -49,6 +96,9 @@ export function withAnswerArtifact(result = {}, context = {}) {
     };
 }
 
+/**
+ * @param {AnswerArtifactInput} [artifact]
+ */
 export function summarizeAnswerArtifact(artifact = {}) {
     const normalized = createAnswerArtifact(artifact);
     return {
@@ -62,15 +112,27 @@ export function summarizeAnswerArtifact(artifact = {}) {
     };
 }
 
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
 function normalizeCaptureMethod(value) {
     const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
     return CAPTURE_METHODS.has(normalized) ? normalized : 'unknown';
 }
 
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
 function normalizeText(value) {
     return typeof value === 'string' ? value : '';
 }
 
+/**
+ * @param {{ capturedBy: string, markdown: string, text: string }} args
+ * @returns {number}
+ */
 function estimateExactnessScore({ capturedBy, markdown, text }) {
     if (!markdown && !text) return 0;
     if (capturedBy === 'copy-button' || capturedBy === 'clipboard') return 1;
@@ -79,6 +141,10 @@ function estimateExactnessScore({ capturedBy, markdown, text }) {
     return 0.5;
 }
 
+/**
+ * @param {number} value
+ * @returns {number}
+ */
 function clampScore(value) {
     if (!Number.isFinite(value)) return 0;
     return Math.max(0, Math.min(1, value));

--- a/web-ai/answer-artifact.mjs
+++ b/web-ai/answer-artifact.mjs
@@ -83,6 +83,7 @@ export function artifactFromPollResult(result = {}, context = {}) {
 
 /**
  * @template {Record<string, any>} R
+ *   `Record<string, any>` (not `unknown`) is required for `R & { ... }` spread compatibility in checkJs.
  * @param {R} [result]
  * @param {Record<string, any>} [context]
  * @returns {R & { answerArtifact?: AnswerArtifact }}

--- a/web-ai/capability.mjs
+++ b/web-ai/capability.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 // Phase 3 capability runtime.
 //
 // IDs use cli-jaw's hyphenated convention so the two repos can converge
@@ -15,12 +16,30 @@
 // prompts or mutate model selection. Probes that open menus must close
 // them before resolving.
 
+/**
+ * @typedef {{ state: string, evidence: unknown, next: string }} CapabilityProbeResult
+ * @typedef {{ capabilityId: string, probeFn: (deps: unknown, input: Record<string, unknown>) => Promise<CapabilityProbeResult> }} CapabilityDef
+ * @typedef {{ capabilityId: string, state: string, evidence: unknown, next: string }} CapabilityRow
+ */
+
+/**
+ * @param {string} capabilityId
+ * @param {CapabilityDef['probeFn']} probeFn
+ * @returns {CapabilityDef}
+ */
 export function defineCapability(capabilityId, probeFn) {
     if (typeof probeFn !== 'function') throw new Error(`capability ${capabilityId} requires a probe function`);
     return { capabilityId, probeFn };
 }
 
+/**
+ * @param {unknown} deps
+ * @param {CapabilityDef[]} capabilities
+ * @param {{ probe?: string, [k: string]: unknown }} [input]
+ * @returns {Promise<CapabilityRow[]>}
+ */
 export async function runCapabilities(deps, capabilities, input = {}) {
+    /** @type {CapabilityRow[]} */
     const rows = [];
     for (const cap of capabilities) {
         if (input.probe && input.probe !== cap.capabilityId) continue;
@@ -28,10 +47,11 @@ export async function runCapabilities(deps, capabilities, input = {}) {
             const probeResult = await cap.probeFn(deps, input);
             rows.push({ capabilityId: cap.capabilityId, ...normalizeRow(probeResult) });
         } catch (err) {
+            const e = /** @type {{ message?: string }} */ (err);
             rows.push({
                 capabilityId: cap.capabilityId,
                 state: 'unknown',
-                evidence: { error: err?.message || String(err) },
+                evidence: { error: e?.message || String(err) },
                 next: 're-snapshot',
             });
         }
@@ -39,14 +59,22 @@ export async function runCapabilities(deps, capabilities, input = {}) {
     return rows;
 }
 
+/**
+ * @param {CapabilityRow[]} rows
+ * @returns {string}
+ */
 export function worstCapabilityState(rows) {
     if (!Array.isArray(rows) || rows.length === 0) return 'unknown';
-    if (rows.some(r => r.state === 'fail')) return 'fail';
-    if (rows.some(r => r.state === 'warn')) return 'warn';
-    if (rows.every(r => r.state === 'ok')) return 'ok';
+    if (rows.some((r) => r.state === 'fail')) return 'fail';
+    if (rows.some((r) => r.state === 'warn')) return 'warn';
+    if (rows.every((r) => r.state === 'ok')) return 'ok';
     return 'unknown';
 }
 
+/**
+ * @param {Partial<CapabilityProbeResult>} [probeResult]
+ * @returns {{ state: string, evidence: unknown, next: string }}
+ */
 function normalizeRow(probeResult = {}) {
     return {
         state: probeResult.state || 'unknown',
@@ -55,6 +83,10 @@ function normalizeRow(probeResult = {}) {
     };
 }
 
+/**
+ * @param {{ url?: () => string }|null|undefined} page
+ * @param {Set<string>} expectedHosts
+ */
 export async function probeHostMatches(page, expectedHosts) {
     try {
         const url = page?.url?.() || '';
@@ -66,6 +98,11 @@ export async function probeHostMatches(page, expectedHosts) {
     }
 }
 
+/**
+ * @param {any} page
+ * @param {string[]} selectors
+ * @param {{ timeoutMs?: number, okNext?: string, failState?: string, failNext?: string }} [options]
+ */
 export async function probeFirstVisibleSelector(page, selectors, options = {}) {
     const timeoutMs = options.timeoutMs ?? 1500;
     const deadline = Date.now() + timeoutMs;

--- a/web-ai/capability.mjs
+++ b/web-ai/capability.mjs
@@ -47,11 +47,11 @@ export async function runCapabilities(deps, capabilities, input = {}) {
             const probeResult = await cap.probeFn(deps, input);
             rows.push({ capabilityId: cap.capabilityId, ...normalizeRow(probeResult) });
         } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
+            const e = /** @type {{ message?: string }} */ (err);
             rows.push({
                 capabilityId: cap.capabilityId,
                 state: 'unknown',
-                evidence: { error: message },
+                evidence: { error: e?.message || String(err) },
                 next: 're-snapshot',
             });
         }

--- a/web-ai/capability.mjs
+++ b/web-ai/capability.mjs
@@ -47,11 +47,11 @@ export async function runCapabilities(deps, capabilities, input = {}) {
             const probeResult = await cap.probeFn(deps, input);
             rows.push({ capabilityId: cap.capabilityId, ...normalizeRow(probeResult) });
         } catch (err) {
-            const e = /** @type {{ message?: string }} */ (err);
+            const message = err instanceof Error ? err.message : String(err);
             rows.push({
                 capabilityId: cap.capabilityId,
                 state: 'unknown',
-                evidence: { error: e?.message || String(err) },
+                evidence: { error: message },
                 next: 're-snapshot',
             });
         }

--- a/web-ai/mcp-state.mjs
+++ b/web-ai/mcp-state.mjs
@@ -1,5 +1,23 @@
+// @ts-check
+
+/**
+ * @typedef {{ snapshotId?: string, [extra: string]: unknown }} McpSnapshot
+ */
+
+/**
+ * @typedef {{
+ *   latestSnapshot?: McpSnapshot,
+ *   latestSnapshots?: Record<string, McpSnapshot>,
+ *   [extra: string]: unknown,
+ * }} McpState
+ */
+
 const SNAPSHOT_SCOPES = new Set(['web_ai', 'browser']);
 
+/**
+ * @param {Partial<McpState>} [state]
+ * @returns {McpState}
+ */
 export function ensureMcpState(state = {}) {
     if (!state.latestSnapshots || typeof state.latestSnapshots !== 'object' || Array.isArray(state.latestSnapshots)) {
         state.latestSnapshots = {};
@@ -7,28 +25,48 @@ export function ensureMcpState(state = {}) {
     if (state.latestSnapshot && !state.latestSnapshots.web_ai) {
         state.latestSnapshots.web_ai = state.latestSnapshot;
     }
-    return state;
+    return /** @type {McpState} */ (state);
 }
 
+/**
+ * @param {Partial<McpState>} state
+ * @param {string} scope
+ * @param {McpSnapshot} snapshot
+ * @returns {McpSnapshot}
+ */
 export function setLatestSnapshot(state, scope, snapshot) {
     assertSnapshotScope(scope);
     const normalized = ensureMcpState(state);
-    normalized.latestSnapshots[scope] = snapshot;
+    /** @type {Record<string, McpSnapshot>} */ (normalized.latestSnapshots)[scope] = snapshot;
     if (scope === 'web_ai') normalized.latestSnapshot = snapshot;
     return snapshot;
 }
 
+/**
+ * @param {Partial<McpState>} state
+ * @param {string} scope
+ * @returns {McpSnapshot|null}
+ */
 export function getLatestSnapshot(state, scope) {
     assertSnapshotScope(scope);
-    return ensureMcpState(state).latestSnapshots[scope] || null;
+    return /** @type {Record<string, McpSnapshot>} */ (ensureMcpState(state).latestSnapshots)[scope] || null;
 }
 
+/**
+ * @param {Partial<McpState>} state
+ * @param {string} scope
+ * @param {string} snapshotId
+ * @returns {McpSnapshot}
+ */
 export function requireLatestSnapshot(state, scope, snapshotId) {
     const snapshot = getLatestSnapshot(state, scope);
     if (!snapshot || snapshot.snapshotId !== snapshotId) throw new Error('stale snapshotId');
     return snapshot;
 }
 
+/**
+ * @param {string} scope
+ */
 function assertSnapshotScope(scope) {
     if (!SNAPSHOT_SCOPES.has(scope)) throw new Error(`unknown MCP snapshot scope: ${scope}`);
 }

--- a/web-ai/policy/enforce.mjs
+++ b/web-ai/policy/enforce.mjs
@@ -1,11 +1,39 @@
+// @ts-check
 import { loadPolicy, normalizePolicy, policyError } from './schema.mjs';
 
+/**
+ * @typedef {import('./schema.mjs').WebAiPolicy} WebAiPolicy
+ */
+
+/**
+ * @typedef {{
+ *   url?: string,
+ *   upload?: boolean,
+ *   explicitUpload?: boolean,
+ *   clipboardRead?: boolean,
+ *   evaluate?: boolean,
+ *   fileAccess?: boolean,
+ *   unsafeAllow?: string[],
+ *   [extra: string]: unknown,
+ * }} PolicyAction
+ */
+
+/**
+ * @param {{ policyPath?: string|null }} [input]
+ * @param {PolicyAction} [action]
+ * @returns {Promise<WebAiPolicy>}
+ */
 export async function loadAndEnforcePolicy(input = {}, action = {}) {
     const policy = await loadPolicy(input.policyPath);
     enforcePolicy(policy, action);
     return policy;
 }
 
+/**
+ * @param {unknown} [policyInput]
+ * @param {PolicyAction} [action]
+ * @returns {{ ok: true, policy: WebAiPolicy }}
+ */
 export function enforcePolicy(policyInput = {}, action = {}) {
     const policy = normalizePolicy(policyInput);
     const origin = originOf(action.url);
@@ -36,6 +64,10 @@ export function enforcePolicy(policyInput = {}, action = {}) {
     return { ok: true, policy };
 }
 
+/**
+ * @param {string|null|undefined} url
+ * @returns {string|null}
+ */
 function originOf(url) {
     try {
         return url ? new URL(url).origin : null;

--- a/web-ai/ref-registry.mjs
+++ b/web-ai/ref-registry.mjs
@@ -1,5 +1,26 @@
+// @ts-check
 import { WebAiError } from './errors.mjs';
 
+/**
+ * @typedef {{
+ *   snapshotId: string|null,
+ *   axHash: string|null,
+ *   domHash: string|null,
+ *   refs: Record<string, unknown>,
+ *   createdAt: number,
+ *   stale: boolean,
+ *   invalidatedAt: number|null,
+ * }} RefRegistry
+ */
+
+/**
+ * @typedef {{ snapshotId?: string, axHash?: string, domHash?: string, refs?: Record<string, unknown> }} SnapshotInput
+ */
+
+/**
+ * @param {SnapshotInput|null|undefined} snapshot
+ * @returns {RefRegistry}
+ */
 export function createRefRegistry(snapshot) {
     return {
         snapshotId: snapshot?.snapshotId || null,
@@ -12,6 +33,13 @@ export function createRefRegistry(snapshot) {
     };
 }
 
+/**
+ * @param {unknown} page
+ * @param {RefRegistry|null|undefined} registry
+ * @param {string} ref
+ * @param {{ expectedSnapshotId?: string|null, currentDomHash?: string|null, currentAxHash?: string|null, allowStale?: boolean }} [options]
+ * @returns {Promise<unknown>}
+ */
 export async function resolveRef(page, registry, ref, {
     expectedSnapshotId = null,
     currentDomHash = null,
@@ -36,6 +64,11 @@ export async function resolveRef(page, registry, ref, {
     return entry;
 }
 
+/**
+ * @param {RefRegistry|null|undefined} registry
+ * @param {{ domHash?: string|null, axHash?: string|null }} [args]
+ * @returns {boolean}
+ */
 export function invalidateRefsOnDomChange(registry, { domHash = null, axHash = null } = {}) {
     if (!registry) return false;
     const changed = (domHash && registry.domHash && domHash !== registry.domHash)
@@ -49,6 +82,11 @@ export function invalidateRefsOnDomChange(registry, { domHash = null, axHash = n
     return true;
 }
 
+/**
+ * @param {RefRegistry|null|undefined} registry
+ * @param {{ expectedSnapshotId?: string|null, currentDomHash?: string|null, currentAxHash?: string|null }} [args]
+ * @returns {boolean}
+ */
 export function isRegistryStale(registry, {
     expectedSnapshotId = null,
     currentDomHash = null,
@@ -61,6 +99,10 @@ export function isRegistryStale(registry, {
     return false;
 }
 
+/**
+ * @param {RefRegistry|null|undefined} registry
+ * @param {{ expectedSnapshotId?: string|null, currentDomHash?: string|null, currentAxHash?: string|null, ref?: string }} [context]
+ */
 function assertRegistryFresh(registry, context = {}) {
     if (!isRegistryStale(registry, context)) return;
     throw new WebAiError({
@@ -79,6 +121,10 @@ function assertRegistryFresh(registry, context = {}) {
     });
 }
 
+/**
+ * @param {unknown} ref
+ * @returns {string}
+ */
 function normalizeRef(ref) {
     const value = String(ref || '').trim();
     if (!value) return value;

--- a/web-ai/tool-schema.mjs
+++ b/web-ai/tool-schema.mjs
@@ -3,6 +3,7 @@ import { BROWSER_TOOLS, isKnownBrowserTool } from './browser-tool-schema.mjs';
 
 /**
  * @typedef {{ description: string, inputSchema: Record<string, unknown> }} ToolDefinition
+ * @typedef {{ name: string, description?: string, inputSchema?: unknown, parameters?: unknown }} ToolSchema
  */
 
 const providerEnum = ['chatgpt', 'gemini', 'grok'];
@@ -83,9 +84,12 @@ export const WEB_AI_TOOLS = {
 };
 
 /** @type {Record<string, ToolDefinition>} */
+const browserToolsChecked = BROWSER_TOOLS;
+
+/** @type {Record<string, ToolDefinition>} */
 export const MCP_TOOLS = {
     ...WEB_AI_TOOLS,
-    .../** @type {Record<string, ToolDefinition>} */ (BROWSER_TOOLS),
+    ...browserToolsChecked,
 };
 
 /**
@@ -116,9 +120,10 @@ export function toolSchemaForAiSdk(toolName) {
 
 /**
  * @param {string} [format]
+ * @returns {Array<ToolSchema|null>}
  */
 export function allToolSchemas(format = 'mcp') {
-    /** @type {(name: string) => unknown} */
+    /** @type {(name: string) => ToolSchema|null} */
     const mapper = format === 'ai-sdk' ? toolSchemaForAiSdk : toolSchemaForMcp;
     return Object.keys(MCP_TOOLS).map((name) => mapper(name));
 }

--- a/web-ai/tool-schema.mjs
+++ b/web-ai/tool-schema.mjs
@@ -1,7 +1,16 @@
+// @ts-check
 import { BROWSER_TOOLS, isKnownBrowserTool } from './browser-tool-schema.mjs';
+
+/**
+ * @typedef {{ description: string, inputSchema: Record<string, unknown> }} ToolDefinition
+ */
 
 const providerEnum = ['chatgpt', 'gemini', 'grok'];
 
+/**
+ * @param {Record<string, unknown>} properties
+ * @param {string[]} [required]
+ */
 const objectSchema = (properties, required = []) => ({
     type: 'object',
     properties,
@@ -9,6 +18,7 @@ const objectSchema = (properties, required = []) => ({
     additionalProperties: false,
 });
 
+/** @type {Record<string, ToolDefinition>} */
 export const WEB_AI_TOOLS = {
     web_ai_snapshot: {
         description: 'Return compact accessibility snapshot with @eN refs.',
@@ -72,11 +82,15 @@ export const WEB_AI_TOOLS = {
     },
 };
 
+/** @type {Record<string, ToolDefinition>} */
 export const MCP_TOOLS = {
     ...WEB_AI_TOOLS,
-    ...BROWSER_TOOLS,
+    .../** @type {Record<string, ToolDefinition>} */ (BROWSER_TOOLS),
 };
 
+/**
+ * @param {string} toolName
+ */
 export function toolSchemaForMcp(toolName) {
     const tool = MCP_TOOLS[toolName];
     if (!tool) return null;
@@ -87,6 +101,9 @@ export function toolSchemaForMcp(toolName) {
     };
 }
 
+/**
+ * @param {string} toolName
+ */
 export function toolSchemaForAiSdk(toolName) {
     const tool = MCP_TOOLS[toolName];
     if (!tool) return null;
@@ -97,15 +114,27 @@ export function toolSchemaForAiSdk(toolName) {
     };
 }
 
+/**
+ * @param {string} [format]
+ */
 export function allToolSchemas(format = 'mcp') {
+    /** @type {(name: string) => unknown} */
     const mapper = format === 'ai-sdk' ? toolSchemaForAiSdk : toolSchemaForMcp;
-    return Object.keys(MCP_TOOLS).map(mapper);
+    return Object.keys(MCP_TOOLS).map((name) => mapper(name));
 }
 
+/**
+ * @param {string} toolName
+ * @returns {boolean}
+ */
 export function isKnownMcpTool(toolName) {
     return Boolean(MCP_TOOLS[toolName]);
 }
 
+/**
+ * @param {string} toolName
+ * @returns {boolean}
+ */
 export function isKnownWebAiTool(toolName) {
     return Boolean(WEB_AI_TOOLS[toolName]);
 }

--- a/web-ai/trace/writer.mjs
+++ b/web-ai/trace/writer.mjs
@@ -1,8 +1,33 @@
+// @ts-check
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createTraceRecord } from './types.mjs';
 import { redactTraceValue } from './redact.mjs';
 
+/**
+ * @typedef {{
+ *   traceId?: string,
+ *   command?: string,
+ *   provider?: string|null,
+ *   modelAlias?: string|null,
+ *   sessionId?: string|null,
+ *   targetId?: string|null,
+ *   url?: string|null,
+ *   urlOrigin?: string|null,
+ *   status?: string,
+ *   errorEnvelope?: unknown,
+ *   evidence?: Record<string, unknown>,
+ *   steps?: unknown[],
+ *   artifacts?: unknown[],
+ *   [extra: string]: unknown,
+ * }} TraceWriteInput
+ */
+
+/**
+ * @param {string|null|undefined} traceDir
+ * @param {TraceWriteInput} record
+ * @returns {Promise<string|null>}
+ */
 export async function appendTraceRecord(traceDir, record) {
     if (!traceDir) return null;
     const absoluteDir = path.resolve(traceDir);
@@ -16,6 +41,11 @@ export async function appendTraceRecord(traceDir, record) {
     return filePath;
 }
 
+/**
+ * @param {string|null|undefined} traceDir
+ * @param {TraceWriteInput} [input]
+ * @returns {Promise<string|null>}
+ */
 export async function writeCommandTrace(traceDir, {
     traceId,
     command,


### PR DESCRIPTION
Extends `tsconfig.checkjs.json` from 23 to 31 entries. Adds `// @ts-check` + JSDoc to 8 leaf utility modules. No new deps, no behavior change, no rename.

## Files (8)
- web-ai/mcp-state.mjs
- web-ai/policy/enforce.mjs
- web-ai/trace/writer.mjs
- web-ai/action-trace.mjs
- web-ai/capability.mjs
- web-ai/answer-artifact.mjs
- web-ai/ref-registry.mjs
- web-ai/tool-schema.mjs

## Pro-honored patterns
- No runtime-changing JS (preserved `|| 0`, `String(x)`, `(err)?.message`).
- Explicit typedefs to avoid literal-narrowing of `typeof OBJECT_LITERAL`.
- `Record<string, ToolDefinition>` cast on `BROWSER_TOOLS` spread.
- `TraceWriteInput` typedef matches canonical `createTraceRecord` signature in `trace/types.mjs` instead of redefining a looser one.
- `allToolSchemas` wraps mapper in a closure to avoid `Array#map` arity bleed.

## Gates
 31 .mjs entries
- `npm run typecheck` 
- `npm run typecheck:checkjs-dom` 
- `npm run smoke:bins` 
 473 passed, 12 skipped
- Negative probe (TS2322) verified

See `devlog/_plan/strict-migration/phases/03-P07-leaf-runtime.md` for full notes.