### PR TITLE
P08: context-pack leaf JSDoc opt-in (4 files)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P08-context-pack-leaves.md
+++ b/devlog/_plan/strict-migration/phases/03-P08-context-pack-leaves.md
@@ -10,7 +10,7 @@ Extend `tsconfig.checkjs.json` to cover the leaf modules of the `web-ai/context-
 |------|-------|-------|
 | `web-ai/context-pack/constants.mjs` | 39 | constant exports only; trivial `// @ts-check` |
 | `web-ai/context-pack/token-estimator.mjs` | 42 | `BudgetInput`/`BudgetReport` typedefs; `Record<string, Record<string, number>>` cast on `DEFAULT_MODEL_INPUT_BUDGETS` to allow vendor/model lookups |
-| `web-ai/context-pack/report.mjs` | 70 | `ContextDryRunResult`/`ContextFileRow`/`ContextAttachment`/`ReportOptions` typedefs; renderer return type `string` (with `|| ''` fallback when transport text undefined) |
+| `web-ai/context-pack/report.mjs` | 70 | `ContextDryRunResult`/`ContextFileRow`/`ContextAttachment`/`ReportOptions` typedefs; `model?: string` and renderer return type `string|undefined` to preserve original ternary's undefined-edge runtime |
 | `web-ai/context-pack/renderer.mjs` | 79 | `ContextRenderInput`/`ContextFile` typedefs; existing imports of `WebAiError`/`buildBudgetReport` already type-checked |
 
 Total checked .mjs files in tsconfig.checkjs.json: 30 → **34** (verified by `--listFiles`).

--- a/devlog/_plan/strict-migration/phases/03-P08-context-pack-leaves.md
+++ b/devlog/_plan/strict-migration/phases/03-P08-context-pack-leaves.md
@@ -1,0 +1,39 @@
+# P08 — Context-Pack Leaf Helpers (JSDoc opt-in, 4 files)
+
+## Scope
+
+Extend `tsconfig.checkjs.json` to cover the leaf modules of the `web-ai/context-pack/*` namespace. No new deps, no behavior change, no rename. Pure annotation + sibling tsconfig include.
+
+## Files (4)
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `web-ai/context-pack/constants.mjs` | 39 | constant exports only; trivial `// @ts-check` |
+| `web-ai/context-pack/token-estimator.mjs` | 42 | `BudgetInput`/`BudgetReport` typedefs; `Record<string, Record<string, number>>` cast on `DEFAULT_MODEL_INPUT_BUDGETS` to allow vendor/model lookups |
+| `web-ai/context-pack/report.mjs` | 70 | `ContextDryRunResult`/`ContextFileRow`/`ContextAttachment`/`ReportOptions` typedefs; renderer return type `string` (with `|| ''` fallback when transport text undefined) |
+| `web-ai/context-pack/renderer.mjs` | 79 | `ContextRenderInput`/`ContextFile` typedefs; existing imports of `WebAiError`/`buildBudgetReport` already type-checked |
+
+Total checked .mjs files in tsconfig.checkjs.json: 30 → **34** (verified by `--listFiles`).
+
+## Pro-honored patterns
+
+- No runtime-changing JS. `renderContextDryRunReport` returns `string|undefined` (instead of forcing `string`) so the original `result.composerText`/`result.attachmentText` value — including `undefined` in edge cases — is returned exactly as before.
+- `BudgetInput` typedef with optional `inlineCharLimit` matches all call sites; `Number(input.inlineCharLimit || DEFAULT_BROWSER_INLINE_CHAR_BUDGET)` preserved.
+- `DEFAULT_MODEL_INPUT_BUDGETS` is locally re-narrowed via `/** @type {Record<string, Record<string, number>>} */` to allow vendor/model dynamic lookup without widening the constants module's literal type.
+- `ContextDryRunResult.budget.status` typed as `string` (not the `'ok'|'warning'|'over-budget'` literal union from token-estimator), because the report-renderer is consumer-side and shouldn't constrain producer literals.
+- File-row `language?: string` is optional and falls back to `languageFromPath()` at render time — preserved.
+
+## Gates (all green)
+
+- `npx tsc --noEmit -p tsconfig.checkjs.json --listFiles` → 34 .mjs entries
+- `npm run typecheck` ✓
+- `npm run typecheck:checkjs-dom` ✓ (3 entries unchanged)
+- `npm run smoke:bins` ✓
+- `npm test` → 473 passed, 12 skipped (no regression)
+
+## Out of scope
+
+- `context-pack/index.mjs` re-exports from `file-selector.mjs` and `builder.mjs` which aren't yet annotated; deferred to P09.
+- `context-pack/builder.mjs`, `context-pack/file-selector.mjs` — pull in `node:fs`, `node:os`, `node:path` and complex types; later batch.
+- DOM-touching modules like `post-action-assert.mjs`, `dom-hash.mjs` already in `tsconfig.checkjs-dom.json` track.
+- Larger session/cli orchestration (P10+).

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -36,7 +36,11 @@
     "web-ai/capability.mjs",
     "web-ai/answer-artifact.mjs",
     "web-ai/ref-registry.mjs",
-    "web-ai/tool-schema.mjs"
+    "web-ai/tool-schema.mjs",
+    "web-ai/context-pack/constants.mjs",
+    "web-ai/context-pack/token-estimator.mjs",
+    "web-ai/context-pack/report.mjs",
+    "web-ai/context-pack/renderer.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/context-pack/constants.mjs
+++ b/web-ai/context-pack/constants.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 export const CONTEXT_PACKAGE_REFERENCE = {
     package: 'agbrowse',
     version: '0.1.3',

--- a/web-ai/context-pack/renderer.mjs
+++ b/web-ai/context-pack/renderer.mjs
@@ -1,7 +1,34 @@
+// @ts-check
 import { extname } from 'node:path';
 import { buildBudgetReport } from './token-estimator.mjs';
 import { WebAiError } from '../errors.mjs';
 
+/**
+ * @typedef {{
+ *   relativePath: string,
+ *   sizeBytes: number,
+ *   estimatedTokens: number,
+ *   language?: string,
+ *   content: string,
+ *   path?: string,
+ * }} ContextFile
+ *
+ * @typedef {{
+ *   prompt?: string,
+ *   vendor?: string,
+ *   model?: string,
+ *   contextTransport?: string,
+ *   inlineOnly?: boolean,
+ *   maxInput?: number,
+ *   inlineCharLimit?: number,
+ * }} ContextRenderInput
+ */
+
+/**
+ * @param {ContextRenderInput} [input]
+ * @param {ContextFile[]} [files]
+ * @returns {string}
+ */
 export function renderContextComposerText(input = {}, files = []) {
     const prompt = String(input.prompt || '').trim();
     if (!prompt) throw new WebAiError({
@@ -15,6 +42,10 @@ export function renderContextComposerText(input = {}, files = []) {
     return [attachmentText, '[USER REQUEST]', prompt].join('\n').trim();
 }
 
+/**
+ * @param {ContextFile[]} [files]
+ * @returns {string}
+ */
 export function renderContextAttachmentText(files = []) {
     const blocks = [
         '[CONTEXT PACKAGE]',
@@ -35,6 +66,12 @@ export function renderContextAttachmentText(files = []) {
     return blocks.join('\n').trim();
 }
 
+/**
+ * @param {ContextRenderInput} [input]
+ * @param {ContextFile[]} [files]
+ * @param {Array<Record<string, unknown>>} [excluded]
+ * @param {string[]} [warnings]
+ */
 export function buildContextRenderResult(input = {}, files = [], excluded = [], warnings = []) {
     const transport = resolveContextTransport(input);
     const inlineComposerText = renderContextComposerText(input, files);
@@ -57,6 +94,10 @@ export function buildContextRenderResult(input = {}, files = [], excluded = [], 
     };
 }
 
+/**
+ * @param {ContextRenderInput} [input]
+ * @returns {string}
+ */
 export function resolveContextTransport(input = {}) {
     const requested = String(input.contextTransport || '').trim().toLowerCase();
     if (requested === 'inline' || requested === 'upload' || requested === 'auto') {
@@ -66,6 +107,10 @@ export function resolveContextTransport(input = {}) {
     return 'upload';
 }
 
+/**
+ * @param {string} [filePath]
+ * @returns {string}
+ */
 export function languageFromPath(filePath = '') {
     const ext = extname(filePath).replace(/^\./, '').toLowerCase();
     if (!ext) return 'text';

--- a/web-ai/context-pack/report.mjs
+++ b/web-ai/context-pack/report.mjs
@@ -20,7 +20,7 @@
  *   ok: boolean,
  *   status: string,
  *   vendor: string,
- *   model: string,
+ *   model?: string,
  *   budget: {
  *     status: string,
  *     estimatedTokens: number,

--- a/web-ai/context-pack/report.mjs
+++ b/web-ai/context-pack/report.mjs
@@ -1,3 +1,55 @@
+// @ts-check
+
+/**
+ * @typedef {{
+ *   path: string,
+ *   relativePath?: string,
+ *   sizeBytes?: number,
+ *   estimatedTokens?: number,
+ *   language?: string,
+ *   reason?: string,
+ * }} ContextFileRow
+ *
+ * @typedef {{
+ *   path: string,
+ *   displayPath?: string,
+ *   sizeBytes?: number,
+ * }} ContextAttachment
+ *
+ * @typedef {{
+ *   ok: boolean,
+ *   status: string,
+ *   vendor: string,
+ *   model: string,
+ *   budget: {
+ *     status: string,
+ *     estimatedTokens: number,
+ *     maxInputTokens: number,
+ *     inlineChars: number,
+ *     inlineCharLimit: number,
+ *   },
+ *   transport?: string,
+ *   files: ContextFileRow[],
+ *   excluded: ContextFileRow[],
+ *   attachments?: ContextAttachment[],
+ *   warnings: string[],
+ *   composerText?: string,
+ *   attachmentText?: string,
+ * }} ContextDryRunResult
+ *
+ * @typedef {{
+ *   mode?: 'summary'|'full'|'json',
+ *   full?: boolean,
+ *   json?: boolean,
+ *   includeComposerText?: boolean,
+ * }} ReportOptions
+ */
+
+/**
+ * @param {ContextDryRunResult} result
+ * @param {ReportOptions} [options]
+ * @returns {string|undefined}
+ */
 export function renderContextDryRunReport(result, options = {}) {
     const mode = options.mode || (options.full ? 'full' : options.json ? 'json' : 'summary');
     if (mode === 'json') return JSON.stringify(toJsonResult(result, options), null, 2);
@@ -5,8 +57,14 @@ export function renderContextDryRunReport(result, options = {}) {
     return renderSummary(result);
 }
 
+/**
+ * @param {ContextDryRunResult} result
+ * @param {ReportOptions} [options]
+ * @returns {Record<string, unknown>}
+ */
 export function toJsonResult(result, options = {}) {
     const includeComposerText = Boolean(options.full || options.includeComposerText);
+    /** @type {Record<string, unknown>} */
     const base = {
         ok: result.ok,
         status: result.status,
@@ -29,6 +87,10 @@ export function toJsonResult(result, options = {}) {
     return base;
 }
 
+/**
+ * @param {ContextDryRunResult} result
+ * @returns {string}
+ */
 function renderSummary(result) {
     const lines = [
         `[context-dry-run] ${result.files.length} files, ~${result.budget.estimatedTokens} / ${result.budget.maxInputTokens} tokens (${result.budget.status})`,

--- a/web-ai/context-pack/token-estimator.mjs
+++ b/web-ai/context-pack/token-estimator.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import {
     DEFAULT_BROWSER_INLINE_CHAR_BUDGET,
     DEFAULT_MODEL_INPUT_BUDGETS,
@@ -6,21 +7,52 @@ import {
 
 const SECTION_OVERHEAD_TOKENS = 16;
 
+/**
+ * @param {string} [text]
+ * @param {number} [sectionCount]
+ * @returns {number}
+ */
 export function estimateTokens(text = '', sectionCount = 1) {
     const chars = String(text || '').length;
     return Math.ceil(chars / 3) + Math.max(0, sectionCount) * SECTION_OVERHEAD_TOKENS;
 }
 
+/**
+ * @typedef {{ maxInput?: number, vendor?: string, model?: string, inlineCharLimit?: number }} BudgetInput
+ */
+
+/**
+ * @param {BudgetInput} [input]
+ * @returns {number}
+ */
 export function resolveMaxInputTokens(input = {}) {
     const explicit = Number(input.maxInput || 0);
     if (Number.isFinite(explicit) && explicit > 0) return Math.floor(explicit);
 
     const vendor = String(input.vendor || 'chatgpt').toLowerCase();
     const model = String(input.model || 'default').toLowerCase();
-    const vendorBudgets = DEFAULT_MODEL_INPUT_BUDGETS[vendor] || DEFAULT_MODEL_INPUT_BUDGETS.chatgpt;
-    return vendorBudgets[model] || vendorBudgets.default || DEFAULT_MODEL_INPUT_BUDGETS.chatgpt.default;
+    /** @type {Record<string, Record<string, number>>} */
+    const allBudgets = DEFAULT_MODEL_INPUT_BUDGETS;
+    const vendorBudgets = allBudgets[vendor] || allBudgets.chatgpt;
+    return vendorBudgets[model] || vendorBudgets.default || allBudgets.chatgpt.default;
 }
 
+/**
+ * @typedef {{
+ *   status: 'ok'|'warning'|'over-budget',
+ *   estimatedTokens: number,
+ *   maxInputTokens: number,
+ *   inlineChars: number,
+ *   inlineCharLimit: number,
+ * }} BudgetReport
+ */
+
+/**
+ * @param {BudgetInput} [input]
+ * @param {string} [composerText]
+ * @param {unknown[]} [files]
+ * @returns {BudgetReport}
+ */
 export function buildBudgetReport(input = {}, composerText = '', files = []) {
     const maxInputTokens = resolveMaxInputTokens(input);
     const estimatedTokens = estimateTokens(composerText, files.length + 2);


### PR DESCRIPTION
Extends `tsconfig.checkjs.json` from 30 to 34 .mjs entries. Adds `// @ts-check` + JSDoc to 4 leaf modules of `web-ai/context-pack/*`. No new deps, no behavior change, no rename.

## Files (4)
- web-ai/context-pack/constants.mjs (39 lines)
- web-ai/context-pack/token-estimator.mjs (42)
- web-ai/context-pack/report.mjs (70)
- web-ai/context-pack/renderer.mjs (79)

## Pro-honored patterns
- `renderContextDryRunReport` returns `string|undefined` to preserve original ternary's undefined-edge runtime exactly.
- `DEFAULT_MODEL_INPUT_BUDGETS` cast locally to `Record<string, Record<string, number>>` for dynamic vendor/model lookup without widening the producer module.
- `ContextDryRunResult.budget.status` typed loosely as `string` to avoid coupling consumer to producer's literal union.

## Gates
- checkjs --listFiles: 34 .mjs entries (was 30)
- typecheck / checkjs-dom / smoke:bins / vitest 473 passed

See `devlog/_plan/strict-migration/phases/03-P08-context-pack-leaves.md`.