### PR TITLE
P09: context-pack builder layer (file-selector / builder / index)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P09-context-pack-builders.md
+++ b/devlog/_plan/strict-migration/phases/03-P09-context-pack-builders.md
@@ -1,0 +1,27 @@
+#  context-pack builder layer (file-selector / builder / index)P09 
+
+VERDICT-B (per-phase JSDoc opt-in via tsconfig.checkjs.json). No runtime change.
+
+## Files annotated (3 .mjs newly added to checkjs)
+
+| File | Lines | Notes |
+|------|------:|-------|
+| `web-ai/context-pack/file-selector.mjs` | 195 | `FileSelectorInput` typedef; `ReadContextFileResult` discriminated union (`ok: true \| false`); helpers (`parseContextFile`, `excluded`, `normalizeList`, `unique`, `looksLikeGlob`, `toPosix`, `isBinaryLike`) typed |
+| `web-ai/context-pack/builder.mjs` | 90 | `BuilderInput` widened typedef including `inlineCharLimit`; helpers `overBudgetError`, `inlineLimitError` typed |
+| `web-ai/context-pack/index.mjs` | 6 | `// @ts-check`  re-export shim |only 
+
+## Single typedef-only adjustment to existing P08 file
+ `attachments: /** @type {{path:string,displayPath:string,sizeBytes:number}[]} */ ([])`. JSDoc cast on empty array literal so consumers (builder.mjs) can mutate `result.attachments = [...]` later without `never[]` error. No runtime change.
+
+## Why no `ContextPackResult` import?
+The renderer's actual return shape is wider than `ContextPackResult` (e.g., `transport: string` from `resolveContextTransport`, `excluded: Array<Record<string, unknown>>`). Forcing the narrow typedef would require runtime narrowing or unsafe casts. Per Pro's P08 guidance ("consumer-side widening of producer's literal union is pragmatic"), we let TS infer the renderer's return shape and use a local `BuilderInput` typedef on inputs only.
+
+## tsconfig.checkjs.json
+ 37 .mjs entries.
+
+## Gates
+ 0 errors
+ 0 errors
+ 0 errors
+ ok
+ 473 passed, 12 skipped

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -40,7 +40,10 @@
     "web-ai/context-pack/constants.mjs",
     "web-ai/context-pack/token-estimator.mjs",
     "web-ai/context-pack/report.mjs",
-    "web-ai/context-pack/renderer.mjs"
+    "web-ai/context-pack/renderer.mjs",
+    "web-ai/context-pack/file-selector.mjs",
+    "web-ai/context-pack/builder.mjs",
+    "web-ai/context-pack/index.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/context-pack/builder.mjs
+++ b/web-ai/context-pack/builder.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
@@ -6,8 +7,27 @@ import { buildContextPack } from './file-selector.mjs';
 import { buildContextRenderResult } from './renderer.mjs';
 import { WebAiError } from '../errors.mjs';
 
+/**
+ * @typedef {{
+ *   contextFromFiles?: any,
+ *   contextExclude?: string[],
+ *   contextFile?: string,
+ *   cwd?: string,
+ *   maxFileSize?: number,
+ *   strict?: boolean,
+ *   inlineCharLimit?: number,
+ *   prompt?: string,
+ *   vendor?: string,
+ *   model?: string,
+ *   contextTransport?: string,
+ *   inlineOnly?: boolean,
+ *   maxInput?: number,
+ * }} BuilderInput
+ */
+
 const PACKAGE_DIR = join(process.env.BROWSER_AGENT_HOME || join(homedir(), '.browser-agent'), 'web-ai-context-packages');
 
+/** @param {BuilderInput} [input] */
 export async function buildContextPackageResult(input = {}) {
     const selected = await buildContextPack(input);
     const result = buildContextRenderResult(input, selected.files, selected.excluded, selected.warnings);
@@ -17,6 +37,7 @@ export async function buildContextPackageResult(input = {}) {
     return result;
 }
 
+/** @param {BuilderInput} [input] */
 export async function buildInlineContextOrFail(input = {}) {
     if (!hasContextPackaging(input)) return null;
     const result = await buildContextPackageResult({ ...input, strict: true });
@@ -30,6 +51,7 @@ export async function buildInlineContextOrFail(input = {}) {
     return result;
 }
 
+/** @param {BuilderInput} [input] */
 export async function prepareContextForBrowser(input = {}) {
     if (!hasContextPackaging(input)) return null;
     const result = await buildContextPackageResult({ ...input, strict: true });
@@ -61,6 +83,9 @@ export async function prepareContextForBrowser(input = {}) {
     return result;
 }
 
+/**
+ * @param {{ contextFile?: string, contextFromFiles?: any }} [input]
+ */
 export function hasContextPackaging(input = {}) {
     return Boolean(
         input.contextFile ||
@@ -68,6 +93,7 @@ export function hasContextPackaging(input = {}) {
     );
 }
 
+/** @param {{ estimatedTokens: number, maxInputTokens: number }} budget */
 function overBudgetError(budget) {
     return new WebAiError({
         errorCode: 'context.over-budget',
@@ -78,6 +104,10 @@ function overBudgetError(budget) {
     });
 }
 
+/**
+ * @param {number} length
+ * @param {number} limit
+ */
 function inlineLimitError(length, limit) {
     return new WebAiError({
         errorCode: 'context.over-budget',

--- a/web-ai/context-pack/file-selector.mjs
+++ b/web-ai/context-pack/file-selector.mjs
@@ -1,11 +1,26 @@
+// @ts-check
 import { promises as fs } from 'node:fs';
-import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { relative, resolve, sep } from 'node:path';
 import fg from 'fast-glob';
 import { DEFAULT_EXCLUDES, DEFAULT_MAX_FILE_SIZE_BYTES } from './constants.mjs';
 import { estimateTokens } from './token-estimator.mjs';
 import { languageFromPath } from './renderer.mjs';
 import { WebAiError } from '../errors.mjs';
 
+/**
+ * @typedef {{
+ *   contextFromFiles?: any,
+ *   contextExclude?: string[],
+ *   contextFile?: string,
+ *   cwd?: string,
+ *   maxFileSize?: number,
+ *   strict?: boolean,
+ * }} FileSelectorInput
+ */
+
+/**
+ * @param {FileSelectorInput} [input]
+ */
 export async function buildContextPack(input = {}) {
     const cwd = resolve(input.cwd || process.cwd());
     const patterns = await collectPatterns(input);
@@ -35,6 +50,9 @@ export async function buildContextPack(input = {}) {
     return { files, excluded, warnings };
 }
 
+/**
+ * @param {FileSelectorInput} [input]
+ */
 export async function collectPatterns(input = {}) {
     const include = normalizeList(input.contextFromFiles);
     const exclude = [];
@@ -55,6 +73,11 @@ export async function collectPatterns(input = {}) {
     return { include: unique(include), exclude: unique(exclude) };
 }
 
+/**
+ * @param {string[]} [includePatterns]
+ * @param {string[]} [excludePatterns]
+ * @param {string} [cwd]
+ */
 export async function expandContextPaths(includePatterns = [], excludePatterns = [], cwd = process.cwd()) {
     const literals = [];
     const globs = [];
@@ -107,6 +130,17 @@ export async function expandContextPaths(includePatterns = [], excludePatterns =
         .sort((a, b) => toPosix(relative(cwd, a)).localeCompare(toPosix(relative(cwd, b))));
 }
 
+/**
+ * @typedef {{ ok: true, file: { path: string, relativePath: string, sizeBytes: number, estimatedTokens: number, language: string, content: string } } | { ok: false, excluded: { path: string, relativePath: string, reason: string, sizeBytes?: number } }} ReadContextFileResult
+ */
+
+/**
+ * @param {string} path
+ * @param {string} [cwd]
+ * @param {number} [maxFileSize]
+ * @param {boolean} [strict]
+ * @returns {Promise<ReadContextFileResult>}
+ */
 export async function readContextFile(path, cwd = process.cwd(), maxFileSize = DEFAULT_MAX_FILE_SIZE_BYTES, strict = false) {
     const stat = await fs.lstat(path);
     const relativePath = toPosix(relative(cwd, path));
@@ -144,8 +178,11 @@ export async function readContextFile(path, cwd = process.cwd(), maxFileSize = D
     };
 }
 
+/** @param {string} content */
 function parseContextFile(content) {
+    /** @type {string[]} */
     const include = [];
+    /** @type {string[]} */
     const exclude = [];
     const trimmed = String(content || '').trim();
     if (!trimmed) return { include, exclude };
@@ -164,10 +201,18 @@ function parseContextFile(content) {
     return { include, exclude };
 }
 
+/**
+ * @param {string} path
+ * @param {string} relativePath
+ * @param {string} reason
+ * @param {number} [sizeBytes]
+ * @returns {{ ok: false, excluded: { path: string, relativePath: string, reason: string, sizeBytes?: number } }}
+ */
 function excluded(path, relativePath, reason, sizeBytes) {
     return { ok: false, excluded: { path, relativePath, reason, ...(sizeBytes ? { sizeBytes } : {}) } };
 }
 
+/** @param {unknown} value */
 function normalizeList(value) {
     if (!value) return [];
     return (Array.isArray(value) ? value : [value])
@@ -176,6 +221,7 @@ function normalizeList(value) {
         .filter(Boolean);
 }
 
+/** @param {string[]} values */
 function unique(values) {
     return [...new Set(values)];
 }
@@ -188,6 +234,7 @@ function toPosix(value = '') {
     return String(value).split(sep).join('/');
 }
 
+/** @param {Buffer} buffer */
 function isBinaryLike(buffer) {
     if (buffer.includes(0)) return true;
     const sample = buffer.subarray(0, Math.min(buffer.length, 4096)).toString('utf8');

--- a/web-ai/context-pack/index.mjs
+++ b/web-ai/context-pack/index.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 export * from './constants.mjs';
 export * from './builder.mjs';
 export * from './file-selector.mjs';

--- a/web-ai/context-pack/renderer.mjs
+++ b/web-ai/context-pack/renderer.mjs
@@ -89,7 +89,7 @@ export function buildContextRenderResult(input = {}, files = [], excluded = [], 
         excluded,
         composerText,
         attachmentText,
-        attachments: [],
+        attachments: /** @type {{path:string,displayPath:string,sizeBytes:number}[]} */ ([]),
         warnings,
     };
 }


### PR DESCRIPTION
VERDICT-B P09. No runtime change.

## Scope
37):
- `web-ai/context-pack/file-selector.mjs` (195 lines)
- `web-ai/context-pack/builder.mjs` (90 lines)
- `web-ai/context-pack/index.mjs` (6 lines)

 attachments: /** @type {{...}[]} */ ([])` to permit consumer-side mutation.

## Key decision
Builder uses TS-inferred return from `buildContextRenderResult` rather than narrow `ContextPackResult`  honors Pro's P08 guidance on producer/consumer widening pragmatism.typedef 

## Gates (HEAD f30c834)
 0 errors, 37 .mjs
 0 errors
 0 errors
 ok
 473 passed, 12 skipped

## Devlog
`devlog/_plan/strict-migration/phases/03-P09-context-pack-builders.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>