### PR TITLE
P11: source-audit + grok-model + gemini-model

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P11-source-audit-vendor-models.md
+++ b/devlog/_plan/strict-migration/phases/03-P11-source-audit-vendor-models.md
@@ -1,0 +1,24 @@
+#  source-audit + grok-model + gemini-modelP11 
+
+VERDICT-B per-phase JSDoc opt-in. No runtime change.
+
+ 43 in checkjs)
+
+| File | Lines | Notes |
+|------|------:|-------|
+| `web-ai/source-audit.mjs` | 126 | Pure leaf (no imports). Typedefs `Claim`, `SourceQualityRow`, `AuditGap`, `AuditOptions`, `AuditResult`. JSDoc on `auditSources`, `extractClaims`, `extractInlineSources`, helpers. |
+| `web-ai/grok-model.mjs` | 144 | Playwright DOM via `/// <reference types="playwright-core" />`. Typedefs `GrokModelChoice`, `GrokModelSelectResult`, `GrokModelProbe`. `MODEL_OPTIONS: Record<string, string[]>` + `MODEL_ALIASES: Record<string, string>` widened so string lookups type-check without runtime change. |
+| `web-ai/gemini-model.mjs` | 157 | Same DOM pattern. `GEMINI_DEEP_THINK_ALIASES` widened to `Set<string>`. `usedFallbacks` arrays annotated as `string[]` to avoid `any[]` inference. |
+
+## Pro NEEDS_FIX patterns honored
+- No `instanceof Error` / `Number(...)` / `String(x) || ''` substitutions.
+- No new fallback `|| []` runtime  `MODEL_OPTIONS[choice]` keeps original semantics with `Record<string, string[]>` widening.paths 
+- Set widening (`GEMINI_DEEP_THINK_ALIASES: Set<string>`) typedef-only (P10 pattern Pro endorsed).
+- Local `/** @type {string[]} */` on `const usedFallbacks = []`  typedef-only, no runtime change.initializers 
+
+## Gates
+ 0 errors
+ 0 errors
+ 0 errors
+ ok
+ 473 passed, 12 skipped

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -45,11 +45,13 @@
     "web-ai/context-pack/builder.mjs",
     "web-ai/context-pack/index.mjs",
     "web-ai/action-cache.mjs",
-    "web-ai/question.mjs"
+    "web-ai/question.mjs",
+    "web-ai/source-audit.mjs",
+    "web-ai/grok-model.mjs",
+    "web-ai/gemini-model.mjs"
   ],
   "exclude": [
     "node_modules",
     "dist"
   ]
 }
-

--- a/web-ai/gemini-model.mjs
+++ b/web-ai/gemini-model.mjs
@@ -1,5 +1,26 @@
+// @ts-check
+/// <reference types="playwright-core" />
 import { WebAiError } from './errors.mjs';
 
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('playwright-core').Locator} Locator */
+/** @typedef {'fast'|'thinking'|'pro'} GeminiModelChoice */
+/**
+ * @typedef {{
+ *   requested: string,
+ *   selected: string|null,
+ *   alreadySelected: boolean,
+ *   usedFallbacks: string[],
+ * }} GeminiModelSelectResult
+ *
+ * @typedef {{
+ *   state: 'ok'|'warn'|'fail'|'unknown',
+ *   evidence: Record<string, unknown>,
+ *   next: 'send'|'model-fallback',
+ * }} GeminiModelProbe
+ */
+
+/** @type {Record<string, string>} */
 export const GEMINI_MODEL_ALIASES = {
     fast: 'fast',
     flash: 'fast',
@@ -12,6 +33,7 @@ export const GEMINI_MODEL_ALIASES = {
     '3.1-pro': 'pro',
 };
 
+/** @type {Set<string>} */
 export const GEMINI_DEEP_THINK_ALIASES = new Set([
     'deepthink',
     'deep-think',
@@ -27,23 +49,37 @@ const MODE_BUTTONS = [
     'button[aria-label*="mode picker" i]',
 ];
 
+/** @type {Record<string, { testId: string, labels: string[] }>} */
 const MODE_OPTIONS = {
     fast: { testId: 'bard-mode-option-fast', labels: ['Fast'] },
     thinking: { testId: 'bard-mode-option-thinking', labels: ['Thinking'] },
     pro: { testId: 'bard-mode-option-pro', labels: ['Pro'] },
 };
 
+/**
+ * @param {unknown} model
+ * @returns {string|null}
+ */
 export function normalizeGeminiModelChoice(model) {
     const key = String(model || '').trim().toLowerCase();
     if (!key) return null;
     return GEMINI_MODEL_ALIASES[key] || null;
 }
 
+/**
+ * @param {unknown} model
+ * @returns {boolean}
+ */
 export function isGeminiDeepThinkChoice(model) {
     const key = String(model || '').trim().toLowerCase();
     return GEMINI_DEEP_THINK_ALIASES.has(key);
 }
 
+/**
+ * @param {Page} page
+ * @param {unknown} model
+ * @returns {Promise<GeminiModelSelectResult|null>}
+ */
 export async function selectGeminiModel(page, model) {
     if (isGeminiDeepThinkChoice(model)) return null;
     const requested = normalizeGeminiModelChoice(model);
@@ -51,7 +87,7 @@ export async function selectGeminiModel(page, model) {
         if (model) throw new WebAiError({ errorCode: 'provider.model-mismatch', stage: 'provider-select-mode', vendor: 'gemini', retryHint: 'model-fallback', message: `unsupported Gemini model selection: ${model}`, evidence: { model } });
         return null;
     }
-    const usedFallbacks = [];
+    /** @type {string[]} */ const usedFallbacks = [];
     const before = await readGeminiModel(page);
     if (before === requested) return { requested, selected: before, alreadySelected: true, usedFallbacks };
     await openGeminiModelMenu(page, usedFallbacks);
@@ -64,6 +100,10 @@ export async function selectGeminiModel(page, model) {
     return { requested, selected: after, alreadySelected: false, usedFallbacks };
 }
 
+/**
+ * @param {Page} page
+ * @param {string[]} usedFallbacks
+ */
 async function openGeminiModelMenu(page, usedFallbacks) {
     const modeItems = page.locator('[data-test-id^="bard-mode-option-"], [role="menuitem"]').filter({ hasText: /^Fast\b|^Thinking\b|^Pro\b/i });
     if (await modeItems.first().isVisible().catch(() => false)) return;
@@ -95,6 +135,11 @@ async function openGeminiModelMenu(page, usedFallbacks) {
     });
 }
 
+/**
+ * @param {Page} page
+ * @param {string} choice
+ * @returns {Promise<Locator|null>}
+ */
 async function findGeminiModelOption(page, choice) {
     const option = MODE_OPTIONS[choice];
     const deadline = Date.now() + 5_000;
@@ -115,6 +160,11 @@ async function findGeminiModelOption(page, choice) {
     return null;
 }
 
+/**
+ * @param {Page} page
+ * @param {unknown} model
+ * @returns {Promise<GeminiModelProbe>}
+ */
 export async function geminiModelCapabilityProbe(page, model) {
     if (isGeminiDeepThinkChoice(model)) {
         return { state: 'unknown', evidence: { requested: model, tool: 'deepthink' }, next: 'send' };
@@ -124,7 +174,7 @@ export async function geminiModelCapabilityProbe(page, model) {
     if (!requested) return { state: 'fail', evidence: { requested: model }, next: 'model-fallback' };
     const active = await readGeminiModel(page).catch(() => null);
     if (active === requested) return { state: 'ok', evidence: { active, requested, selectable: true }, next: 'send' };
-    const usedFallbacks = [];
+    /** @type {string[]} */ const usedFallbacks = [];
     try {
         await openGeminiModelMenu(page, usedFallbacks);
     } catch {
@@ -137,6 +187,7 @@ export async function geminiModelCapabilityProbe(page, model) {
         : { state: 'fail', evidence: { active, requested, selectable: false, usedFallbacks }, next: 'model-fallback' };
 }
 
+/** @param {Page} page */
 async function closeGeminiModelMenu(page) {
     for (let i = 0; i < 3; i += 1) {
         const menuVisible = await page.locator('[data-test-id^="bard-mode-option-"], [role="menuitem"]')
@@ -147,6 +198,10 @@ async function closeGeminiModelMenu(page) {
     }
 }
 
+/**
+ * @param {Page} page
+ * @returns {Promise<string|null>}
+ */
 async function readGeminiModel(page) {
     for (const selector of MODE_BUTTONS) {
         const loc = page.locator(selector).first();

--- a/web-ai/grok-model.mjs
+++ b/web-ai/grok-model.mjs
@@ -1,5 +1,26 @@
+// @ts-check
+/// <reference types="playwright-core" />
 import { WebAiError } from './errors.mjs';
 
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('playwright-core').Locator} Locator */
+/** @typedef {'auto'|'fast'|'expert'|'grok-4.3'|'heavy'} GrokModelChoice */
+/**
+ * @typedef {{
+ *   requested: string,
+ *   selected: string|null,
+ *   alreadySelected: boolean,
+ *   usedFallbacks: string[],
+ * }} GrokModelSelectResult
+ *
+ * @typedef {{
+ *   state: 'ok'|'warn'|'fail'|'unknown',
+ *   evidence: Record<string, unknown>,
+ *   next: 'send'|'model-fallback',
+ * }} GrokModelProbe
+ */
+
+/** @type {Record<string, string>} */
 export const GROK_MODEL_ALIASES = {
     auto: 'auto',
     automatic: 'auto',
@@ -20,6 +41,7 @@ const MODEL_BUTTONS = [
     'button[aria-label*="Model select" i]',
 ];
 
+/** @type {Record<string, string[]>} */
 const MODEL_OPTIONS = {
     auto: ['Auto'],
     fast: ['Fast'],
@@ -28,19 +50,28 @@ const MODEL_OPTIONS = {
     heavy: ['Heavy'],
 };
 
+/**
+ * @param {unknown} model
+ * @returns {string|null}
+ */
 export function normalizeGrokModelChoice(model) {
     const key = String(model || '').trim().toLowerCase();
     if (!key) return null;
     return GROK_MODEL_ALIASES[key] || null;
 }
 
+/**
+ * @param {Page} page
+ * @param {unknown} model
+ * @returns {Promise<GrokModelSelectResult|null>}
+ */
 export async function selectGrokModel(page, model) {
     const requested = normalizeGrokModelChoice(model);
     if (!requested) {
         if (model) throw new WebAiError({ errorCode: 'provider.model-mismatch', stage: 'provider-select-mode', vendor: 'grok', retryHint: 'model-fallback', message: `unsupported Grok model selection: ${model}`, evidence: { model } });
         return null;
     }
-    const usedFallbacks = [];
+    /** @type {string[]} */ const usedFallbacks = [];
     const before = await readGrokModel(page);
     if (before === requested) return { requested, selected: before, alreadySelected: true, usedFallbacks };
     await openGrokModelMenu(page, usedFallbacks);
@@ -53,6 +84,10 @@ export async function selectGrokModel(page, model) {
     return { requested, selected: after, alreadySelected: false, usedFallbacks };
 }
 
+/**
+ * @param {Page} page
+ * @param {string[]} usedFallbacks
+ */
 async function openGrokModelMenu(page, usedFallbacks) {
     const modelItems = page.locator('[role="menuitem"]').filter({ hasText: /^Auto\b|^Fast\b|^Expert\b|^Grok 4\.3\b|^Heavy\b/i });
     if (await modelItems.first().isVisible().catch(() => false)) return;
@@ -84,6 +119,11 @@ async function openGrokModelMenu(page, usedFallbacks) {
     });
 }
 
+/**
+ * @param {Page} page
+ * @param {string} choice
+ * @returns {Promise<Locator|null>}
+ */
 async function findGrokModelOption(page, choice) {
     const deadline = Date.now() + 5_000;
     while (Date.now() < deadline) {
@@ -101,13 +141,18 @@ async function findGrokModelOption(page, choice) {
     return null;
 }
 
+/**
+ * @param {Page} page
+ * @param {unknown} model
+ * @returns {Promise<GrokModelProbe>}
+ */
 export async function grokModelCapabilityProbe(page, model) {
     const requested = normalizeGrokModelChoice(model);
     if (!model) return { state: 'unknown', evidence: { requested: null }, next: 'send' };
     if (!requested) return { state: 'fail', evidence: { requested: model }, next: 'model-fallback' };
     const active = await readGrokModel(page).catch(() => null);
     if (active === requested) return { state: 'ok', evidence: { active, requested, selectable: true }, next: 'send' };
-    const usedFallbacks = [];
+    /** @type {string[]} */ const usedFallbacks = [];
     try {
         await openGrokModelMenu(page, usedFallbacks);
     } catch {
@@ -120,6 +165,7 @@ export async function grokModelCapabilityProbe(page, model) {
         : { state: 'fail', evidence: { active, requested, selectable: false, usedFallbacks }, next: 'model-fallback' };
 }
 
+/** @param {Page} page */
 async function closeGrokModelMenu(page) {
     for (let i = 0; i < 3; i += 1) {
         const menuVisible = await page.locator('[role="menuitem"]')
@@ -130,6 +176,10 @@ async function closeGrokModelMenu(page) {
     }
 }
 
+/**
+ * @param {Page} page
+ * @returns {Promise<string|null>}
+ */
 async function readGrokModel(page) {
     for (const selector of MODEL_BUTTONS) {
         const loc = page.locator(selector).first();
@@ -139,6 +189,7 @@ async function readGrokModel(page) {
     return null;
 }
 
+/** @param {string} value */
 function escapeRegExp(value) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/web-ai/source-audit.mjs
+++ b/web-ai/source-audit.mjs
@@ -1,8 +1,41 @@
+// @ts-check
+
+/**
+ * @typedef {{ id: string, text: string, sources: string[] }} Claim
+ * @typedef {{
+ *   claimId: string,
+ *   source: string,
+ *   host: string|null,
+ *   quality: 'primary'|'research'|'secondary'|'unknown',
+ * }} SourceQualityRow
+ * @typedef {{ code: string, message: string }} AuditGap
+ * @typedef {{
+ *   requiredSourceRatio?: number,
+ *   checkedScope?: string|null,
+ *   checkedDate?: string|null,
+ * }} AuditOptions
+ * @typedef {{
+ *   claims: Claim[],
+ *   claimsWithInlineSource: Claim[],
+ *   unsourcedClaims: Claim[],
+ *   sourceQualityRows: SourceQualityRow[],
+ *   gaps: AuditGap[],
+ *   ok: boolean,
+ *   checkedScope: string|null,
+ *   checkedDate: string|null,
+ * }} AuditResult
+ */
+
 const SENTENCE_SPLIT = /(?<=[.!?])\s+/u;
 const MARKDOWN_LINK = /\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g;
 const BARE_URL = /\bhttps?:\/\/[^\s)]+/g;
 const ABSENCE_PATTERN = /\b(no|none|never|not found|not available|does not exist|cannot find)\b/i;
 
+/**
+ * @param {string} text
+ * @param {AuditOptions} [options]
+ * @returns {AuditResult}
+ */
 export function auditSources(text, {
     requiredSourceRatio = 1,
     checkedScope = null,
@@ -41,6 +74,10 @@ export function auditSources(text, {
     };
 }
 
+/**
+ * @param {string} [text]
+ * @returns {Claim[]}
+ */
 export function extractClaims(text = '') {
     const claims = [];
     const normalized = stripCodeFences(String(text));
@@ -70,6 +107,10 @@ export function extractClaims(text = '') {
     return claims;
 }
 
+/**
+ * @param {string} [text]
+ * @returns {string[]}
+ */
 export function extractInlineSources(text = '') {
     const sources = new Set();
     for (const match of String(text).matchAll(MARKDOWN_LINK)) {
@@ -81,6 +122,10 @@ export function extractInlineSources(text = '') {
     return Array.from(sources).filter(Boolean);
 }
 
+/**
+ * @param {Claim[]} claims
+ * @returns {SourceQualityRow[]}
+ */
 function buildSourceQualityRows(claims) {
     const rows = [];
     for (const claim of claims) {
@@ -96,18 +141,25 @@ function buildSourceQualityRows(claims) {
     return rows;
 }
 
+/** @param {string} text */
 function stripCodeFences(text) {
     return text.replace(/```[\s\S]*?```/g, '');
 }
 
+/** @param {string} text */
 function looksLikeClaim(text) {
     return /[A-Za-z0-9가-힣]/.test(text) && text.length >= 8;
 }
 
+/** @param {string} url */
 function cleanUrl(url) {
     return String(url).replace(/[.,;:!?]+$/g, '');
 }
 
+/**
+ * @param {string} url
+ * @returns {string|null}
+ */
 function hostOf(url) {
     try {
         return new URL(url).host;
@@ -116,6 +168,10 @@ function hostOf(url) {
     }
 }
 
+/**
+ * @param {string} url
+ * @returns {'primary'|'research'|'secondary'|'unknown'}
+ */
 function classifySourceQuality(url) {
     const host = hostOf(url) || '';
     if (/\b(openai|google|microsoft|github|npmjs|mozilla|w3|chromium)\b/i.test(host)) return 'primary';


### PR DESCRIPTION
VERDICT-B P11. No runtime change.

## Scope (40 -> 43 .mjs in checkjs)
- `web-ai/source-audit.mjs` ( pure leaf, full typedef set126) 
- `web-ai/grok-model.mjs` ( playwright DOM144) 
- `web-ai/gemini-model.mjs` ( playwright DOM157) 

## Notable typedef-only choices
- `Record<string, string[]>` on `MODEL_OPTIONS` / `MODE_OPTIONS` widens key access; no `|| []` runtime fallback added
- `Set<string>` on `GEMINI_DEEP_THINK_ALIASES` (P10 pattern Pro endorsed)
- `/** @type {string[]} */ const usedFallbacks = []` to avoid `any[]` inference

## Gates (HEAD 4ce192a)
 all 0 errors
 473 passed, 12 skipped

## Devlog
`devlog/_plan/strict-migration/phases/03-P11-source-audit-vendor-models.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>