### PR TITLE
chore(strict):  eval-runner.mjs annotation

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P12-eval-runner.md
+++ b/devlog/_plan/strict-migration/phases/03-P12-eval-runner.md
@@ -1,0 +1,20 @@
+# P12 — eval-runner.mjs (web-ai eval orchestrator leaf)
+
+VERDICT-B (per-file `// @ts-check` + JSDoc; no runtime change). Adds `web-ai/eval-runner.mjs` (178 lines) to `tsconfig.checkjs.json`. Runner is a leaf-of-leaves: all `eval/*` deps are already strict-annotated, so we let TS infer the `EvalResult` shape from `web-ai/eval/types.mjs` and `eval/metrics.mjs` rather than redeclaring it.
+
+## Files
+- `web-ai/eval-runner.mjs` — `// @ts-check` header; `EvalFixture` + `EvalRunOptions` typedefs; JSDoc on helpers (`inferVariant`, `htmlToText`, `estimateTokens`, `makeRunId`, `currentGitCommit`, `rejectNetworkFixtureHtml`, `runOneFixture`); `runBounded` annotated with `@template T,R`. Two JSDoc-only casts:
+  - `vendor: /** @type {string|undefined} */ (vendor)` at the `discoverProviderFixtures` call (local `vendor` is `string|null` because of the `options.config ? null : ...` branch; this branch only runs when `config` is null, so vendor is always a string here — cast keeps the typedef-only fix).
+  - `const status = /** @type {'pass'|'fail'} */ (errors.length === 0 ? 'pass' : 'fail')` so the literal narrows for `EvalResult.status: 'pass'|'fail'`.
+- `tsconfig.checkjs.json` — add `web-ai/eval-runner.mjs` (43 → 44).
+
+## Rationale
+- Don't redeclare `EvalResult`/`EvalFixtureResult` locally: `eval/types.mjs` already exports the canonical typedef and `collectMetricRegressions` / `summarizeEvalResults` consume it. A local typedef would diverge.
+- Casts are pure JSDoc — no `String(...)`/`Number(...)`/`|| ''` runtime fallbacks introduced.
+
+## Gates
+- `npm run typecheck` — 0 errors
+- `npm run typecheck:checkjs` — 0 errors
+- `npm run typecheck:checkjs-dom` — 0 errors
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 pass / 12 skipped (no regression)

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -48,7 +48,8 @@
     "web-ai/question.mjs",
     "web-ai/source-audit.mjs",
     "web-ai/grok-model.mjs",
-    "web-ai/gemini-model.mjs"
+    "web-ai/gemini-model.mjs",
+    "web-ai/eval-runner.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/eval-runner.mjs
+++ b/web-ai/eval-runner.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import crypto from 'node:crypto';
@@ -7,8 +8,30 @@ import { DEFAULT_EVAL_RUN_VARIANTS, EVAL_SCHEMA_VERSION, createEvalError, makeRa
 import { EVAL_TARGET_INTENTS, probeEvalTargetIntentFromHtml } from './eval/provider-targets.mjs';
 import { assertScrubbedSafe } from './eval/scrub-dom.mjs';
 
+/**
+ * @typedef {{
+ *   id?: string,
+ *   vendor?: string,
+ *   variant?: string,
+ *   fixturePath?: string,
+ *   scrub?: string[],
+ *   mustContain?: string[],
+ *   mustNotContain?: string[],
+ * }} EvalFixture
+ *
+ * @typedef {{
+ *   vendor?: string|null,
+ *   variants?: string[],
+ *   fixtures?: string,
+ *   config?: string|null,
+ *   concurrency?: number|null,
+ *   maxFixtureConcurrency?: number|null,
+ * }} EvalRunOptions
+ */
+
 const NETWORK_PATTERN = /\b(?:https?:|wss?:|ftp:|file:\/\/)|<(?:script|img|link|iframe|source)\b[^>]*(?:src|href)=["'](?:https?:|\/\/|file:\/\/)/i;
 
+/** @param {EvalRunOptions} [options] */
 export async function runWebAiEval(options = {}) {
     const startedAt = new Date().toISOString();
     const vendor = options.config ? null : normalizeEvalVendor(options.vendor || 'chatgpt');
@@ -19,7 +42,7 @@ export async function runWebAiEval(options = {}) {
         ? config.fixtures
         : await discoverProviderFixtures({
             fixtureDir,
-            vendor,
+            vendor: /** @type {string|undefined} */ (vendor),
             variants: options.variants || DEFAULT_EVAL_RUN_VARIANTS,
         });
     const results = await runBounded(fixtures.map((fixture, index) => ({ fixture, index })), concurrency, async ({ fixture, index }) => {
@@ -54,6 +77,10 @@ export async function runWebAiEval(options = {}) {
     return payload;
 }
 
+/**
+ * @param {EvalFixture} fixture
+ * @param {{ fixtureDir?: string, index?: number }} [opts]
+ */
 export async function runOneFixture(fixture, { fixtureDir = 'test/fixtures/provider-dom', index = 0 } = {}) {
     const provider = normalizeEvalVendor(fixture.vendor);
     const fixturePath = path.resolve(fixture.fixturePath || path.join(fixtureDir, `${provider}-${fixture.variant || 'baseline'}.html`));
@@ -97,7 +124,7 @@ export async function runOneFixture(fixture, { fixtureDir = 'test/fixtures/provi
             probes,
         })));
     }
-    const status = errors.length === 0 ? 'pass' : 'fail';
+    const status = /** @type {'pass'|'fail'} */ (errors.length === 0 ? 'pass' : 'fail');
     const text = htmlToText(html);
     return {
         inputIndex: index,
@@ -120,8 +147,16 @@ export async function runOneFixture(fixture, { fixtureDir = 'test/fixtures/provi
     };
 }
 
+/**
+ * @template T, R
+ * @param {T[]} items
+ * @param {number|null|undefined} limit
+ * @param {(item: T, index: number) => Promise<R>} worker
+ * @returns {Promise<R[]>}
+ */
 export async function runBounded(items, limit, worker) {
     const concurrency = parseFixtureConcurrency(limit);
+    /** @type {R[]} */
     const results = new Array(items.length);
     let cursor = 0;
     async function loop() {
@@ -135,6 +170,7 @@ export async function runBounded(items, limit, worker) {
     return results;
 }
 
+/** @param {string} html */
 export function rejectNetworkFixtureHtml(html) {
     if (NETWORK_PATTERN.test(html)) {
         throw createEvalError('eval.network-blocked', 'fixture-safety', 'fixture contains external network-capable markup');
@@ -142,11 +178,13 @@ export function rejectNetworkFixtureHtml(html) {
     return true;
 }
 
+/** @param {string} filePath */
 function inferVariant(filePath) {
     const base = path.basename(filePath, '.html');
     return base.split('-').slice(1).join('-') || 'baseline';
 }
 
+/** @param {string} html */
 function htmlToText(html) {
     return String(html)
         .replace(/<script[\s\S]*?<\/script>/gi, ' ')
@@ -156,14 +194,20 @@ function htmlToText(html) {
         .trim();
 }
 
+/** @param {string} text */
 function estimateTokens(text) {
     return Math.ceil(String(text || '').length / 4);
 }
 
+/**
+ * @param {string} startedAt
+ * @param {EvalFixture[]} fixtures
+ */
 function makeRunId(startedAt, fixtures) {
     return crypto.createHash('sha256').update(`${startedAt}:${fixtures.map((fixture) => fixture.id || fixture.fixturePath).join('|')}`).digest('hex').slice(0, 16);
 }
 
+/** @returns {Promise<string|null>} */
 async function currentGitCommit() {
     try {
         const head = await fs.readFile('.git/HEAD', 'utf8');


### PR DESCRIPTION
VERDICT-B per-file `// @ts-check` + JSDoc on `web-ai/eval-runner.mjs` (178 lines). Adds to `tsconfig.checkjs.json` (43 -> 44).

- `EvalFixture` + `EvalRunOptions` typedefs; let TS infer `EvalResult` from canonical `eval/types.mjs`.
- JSDoc on all helpers; `runBounded` annotated `@template T,R`.
- Two pure-JSDoc casts (no runtime fallbacks).

Gates: typecheck / typecheck:checkjs / typecheck:checkjs-dom / smoke:bins clean; npm test 473 pass / 12 skipped.