### PR TITLE
chore(strict): P13 - ax-snapshot.mjs annotation

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P13-ax-snapshot.md
+++ b/devlog/_plan/strict-migration/phases/03-P13-ax-snapshot.md
@@ -1,0 +1,21 @@
+# P13 — ax-snapshot.mjs (accessibility snapshot leaf)
+
+VERDICT-B (per-file `// @ts-check` + JSDoc; no runtime change). Adds `web-ai/ax-snapshot.mjs` (234 lines) to `tsconfig.checkjs-dom.json` (sibling DOM-aware sibling tsconfig because the file imports `dom-hash.mjs`, which lives in checkjs-dom).
+
+## Files
+- `web-ai/ax-snapshot.mjs` — `// @ts-check` + `/// <reference types="playwright-core" />`. Five typedefs: `AxNode` (with index signature for dynamic attr access), `InteractiveRef`, `SerializeOptions`, `SerializeContext`, `WebAiSnapshot`. JSDoc on every export and helper.
+  - Pure-JSDoc cast for `node[attr]` dynamic indexing: `/** @type {Record<string, unknown>} */ (node)[attr]`.
+  - Pure-JSDoc cast for `page.accessibility` (Playwright 1.58 removed it from public types but it remains at runtime — the existing guard `if (!ax || typeof ax.snapshot !== 'function')` already preserves runtime safety): cast via `/** @type {unknown} */ (page)` → `Record<string, unknown>` → narrow to typed shape.
+- `tsconfig.checkjs-dom.json` — add `web-ai/ax-snapshot.mjs` (2 → 3 entries).
+
+## Rationale
+- Goes in checkjs-dom (not checkjs) because it imports `dom-hash.mjs` and TS pulls dom-hash into the program; dom-hash uses `document.querySelector` inside `page.evaluate` and needs DOM lib.
+- `AxNode` has explicit fields plus `[key: string]: unknown` for the dynamic attr loop (`for (const attr of [...]) node[attr]`).
+- The `page.accessibility` cast preserves the existing runtime guard — no semantics change. Playwright 1.58 dropped it from public `Page` types but the runtime API is still functional; the guard handles its absence.
+
+## Gates
+- `npm run typecheck` — 0 errors
+- `npm run typecheck:checkjs` — 0 errors
+- `npm run typecheck:checkjs-dom` — 0 errors
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 pass / 12 skipped (no regression)

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -9,7 +9,8 @@
   "include": [
     "types/**/*.d.ts",
     "web-ai/dom-hash.mjs",
-    "web-ai/copy-markdown.mjs"
+    "web-ai/copy-markdown.mjs",
+    "web-ai/ax-snapshot.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/ax-snapshot.mjs
+++ b/web-ai/ax-snapshot.mjs
@@ -1,15 +1,102 @@
+// @ts-check
+/// <reference types="playwright-core" />
 import { createHash, randomUUID } from 'node:crypto';
 import { domHashAround } from './dom-hash.mjs';
 import { WebAiError } from './errors.mjs';
 
+/**
+ * @typedef {{
+ *   role?: string,
+ *   name?: string,
+ *   value?: string|number|boolean,
+ *   description?: string,
+ *   keyshortcuts?: string,
+ *   roledescription?: string,
+ *   valuetext?: string,
+ *   disabled?: boolean,
+ *   expanded?: boolean,
+ *   focused?: boolean,
+ *   focusable?: boolean,
+ *   modal?: boolean,
+ *   multiline?: boolean,
+ *   multiselectable?: boolean,
+ *   readonly?: boolean,
+ *   required?: boolean,
+ *   selected?: boolean,
+ *   checked?: boolean|'mixed',
+ *   pressed?: boolean|'mixed',
+ *   level?: number,
+ *   valuemin?: number,
+ *   valuemax?: number,
+ *   autocomplete?: string,
+ *   haspopup?: string,
+ *   invalid?: string,
+ *   orientation?: string,
+ *   children?: AxNode[],
+ *   [key: string]: unknown,
+ * }} AxNode
+ *
+ * @typedef {{
+ *   ref: string,
+ *   role: string,
+ *   name: string,
+ *   occurrenceIndex: number,
+ *   selector: string|null,
+ *   framePath: string[],
+ *   shadowPath: string[],
+ *   signatureHash: string,
+ * }} InteractiveRef
+ *
+ * @typedef {{
+ *   compact: boolean,
+ *   maxDepth: number,
+ *   refPrefix: string,
+ *   redactText: boolean,
+ * }} SerializeOptions
+ *
+ * @typedef {SerializeOptions & {
+ *   refs: Record<string, InteractiveRef>,
+ *   nextRef: number,
+ *   nodeCount: number,
+ *   occurrenceCounts: Map<string, number>,
+ * }} SerializeContext
+ *
+ * @typedef {{
+ *   snapshotId: string,
+ *   provider: string|null,
+ *   url: string|null,
+ *   domHash: string|null,
+ *   axHash: string,
+ *   text: string,
+ *   refs: Record<string, InteractiveRef>,
+ *   stats: { nodeCount: number, interactiveCount: number, tokenEstimate: number },
+ * }} WebAiSnapshot
+ */
+
 export const DEFAULT_SNAPSHOT_MAX_DEPTH = 6;
 export const DEFAULT_MAX_NAME_CHARS = 900;
+/** @type {Set<string>} */
 export const DEFAULT_INTERACTIVE_ROLES = new Set([
     'button', 'link', 'textbox', 'searchbox', 'combobox', 'checkbox', 'radio',
     'switch', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'option', 'tab',
     'slider', 'spinbutton', 'treeitem', 'listbox', 'gridcell', 'cell',
 ]);
 
+/**
+ * @param {import('playwright-core').Page} page
+ * @param {{
+ *   provider?: string|null,
+ *   compact?: boolean,
+ *   interactiveOnly?: boolean,
+ *   maxDepth?: number,
+ *   rootSelector?: string|null,
+ *   refPrefix?: string,
+ *   redactText?: boolean,
+ *   includeDomHash?: boolean,
+ *   domHashMaxChars?: number,
+ * }} [options]
+ * @returns {Promise<WebAiSnapshot>}
+ */
 export async function buildWebAiSnapshot(page, {
     provider = null,
     compact = true,
@@ -43,23 +130,32 @@ export async function buildWebAiSnapshot(page, {
     };
 }
 
+/** @param {string} snapshotText */
 export function estimateSnapshotTokens(snapshotText) {
     return Math.ceil(String(snapshotText || '').length / 4);
 }
 
+/** @param {string} snapshotText */
 export function hashAccessibilitySnapshot(snapshotText) {
     const normalized = String(snapshotText || '').replace(/\s+/g, ' ').trim();
     return `sha256:${createHash('sha256').update(normalized).digest('hex').slice(0, 16)}`;
 }
 
+/**
+ * @param {WebAiSnapshot|AxNode|null|undefined} snapshot
+ * @param {string} [prefix]
+ * @returns {Record<string, InteractiveRef>}
+ */
 export function extractInteractiveRefs(snapshot, prefix = '@e') {
-    if (snapshot?.refs && typeof snapshot.refs === 'object' && !snapshot.role) {
-        return { ...snapshot.refs };
+    if (snapshot && /** @type {WebAiSnapshot} */ (snapshot).refs && typeof /** @type {WebAiSnapshot} */ (snapshot).refs === 'object' && !(/** @type {AxNode} */ (snapshot).role)) {
+        return { .../** @type {WebAiSnapshot} */ (snapshot).refs };
     }
+    /** @type {Record<string, InteractiveRef>} */
     const refs = {};
     let counter = 1;
+    /** @type {Map<string, number>} */
     const occurrenceCounts = new Map();
-    walkAx(snapshot, (node, depth, path) => {
+    walkAx(/** @type {AxNode} */ (snapshot), (node, depth, path) => {
         if (!isInteractiveNode(node)) return;
         const ref = `${prefix}${counter++}`;
         const name = truncateName(node.name || '');
@@ -81,6 +177,10 @@ export function extractInteractiveRefs(snapshot, prefix = '@e') {
     return refs;
 }
 
+/**
+ * @param {WebAiSnapshot|null|undefined} snapshot
+ * @param {{ maxRefs?: number }} [options]
+ */
 export function summarizeSnapshotForDoctor(snapshot, { maxRefs = 8 } = {}) {
     const refs = Object.values(snapshot?.refs || {}).slice(0, maxRefs);
     return {
@@ -100,8 +200,16 @@ export function summarizeSnapshotForDoctor(snapshot, { maxRefs = 8 } = {}) {
     };
 }
 
+/**
+ * @param {import('playwright-core').Page} page
+ * @param {{ interactiveOnly: boolean, rootSelector: string|null }} options
+ * @returns {Promise<AxNode|null>}
+ */
 async function captureAccessibilitySnapshot(page, { interactiveOnly, rootSelector }) {
-    if (!page?.accessibility || typeof page.accessibility.snapshot !== 'function') {
+    const ax = /** @type {{ snapshot?: (opts: { interestingOnly?: boolean, root?: unknown }) => Promise<AxNode|null> } | undefined} */ (
+        /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (page)).accessibility
+    );
+    if (!ax || typeof ax.snapshot !== 'function') {
         throw new WebAiError({
             errorCode: 'snapshot.unavailable',
             stage: 'snapshot-capture',
@@ -109,6 +217,7 @@ async function captureAccessibilitySnapshot(page, { interactiveOnly, rootSelecto
             message: 'page.accessibility.snapshot() is not available in this Playwright runtime',
         });
     }
+    /** @type {import('playwright-core').ElementHandle|null} */
     let root = null;
     try {
         if (rootSelector) {
@@ -123,7 +232,7 @@ async function captureAccessibilitySnapshot(page, { interactiveOnly, rootSelecto
                 });
             }
         }
-        return await page.accessibility.snapshot({
+        return await ax.snapshot({
             interestingOnly: interactiveOnly,
             ...(root ? { root } : {}),
         });
@@ -132,12 +241,24 @@ async function captureAccessibilitySnapshot(page, { interactiveOnly, rootSelecto
     }
 }
 
+/**
+ * @param {AxNode|null|undefined} tree
+ * @param {SerializeOptions} options
+ */
 function serializeAxTree(tree, options) {
+    /** @type {SerializeContext} */
     const ctx = { ...options, refs: {}, nextRef: 1, nodeCount: 0, occurrenceCounts: new Map() };
     const lines = serializeNode(tree || { role: 'document', name: '' }, 0, ctx, []);
     return { text: lines.join('\n'), refs: ctx.refs, nodeCount: ctx.nodeCount };
 }
 
+/**
+ * @param {AxNode|null|undefined} node
+ * @param {number} depth
+ * @param {SerializeContext} ctx
+ * @param {number[]} path
+ * @returns {string[]}
+ */
 function serializeNode(node, depth, ctx, path) {
     if (!node || depth > ctx.maxDepth) return [];
     ctx.nodeCount += 1;
@@ -145,6 +266,7 @@ function serializeNode(node, depth, ctx, path) {
     const rawName = truncateName(node.name || '');
     const name = ctx.redactText && rawName ? `[redacted:${hashDoctorField(rawName)}]` : rawName;
     const indent = '  '.repeat(depth);
+    /** @type {string[]} */
     const attrs = [];
 
     if (isInteractiveNode(node)) {
@@ -161,8 +283,9 @@ function serializeNode(node, depth, ctx, path) {
         };
     }
     for (const attr of ['checked', 'disabled', 'expanded', 'selected', 'pressed', 'level', 'value']) {
-        if (node[attr] !== undefined && node[attr] !== null && node[attr] !== '') {
-            attrs.push(`${attr}=${formatAttrValue(node[attr])}`);
+        const v = /** @type {Record<string, unknown>} */ (node)[attr];
+        if (v !== undefined && v !== null && v !== '') {
+            attrs.push(`${attr}=${formatAttrValue(v)}`);
         }
     }
 
@@ -182,6 +305,12 @@ function serializeNode(node, depth, ctx, path) {
     return out;
 }
 
+/**
+ * @param {AxNode|null|undefined} node
+ * @param {(node: AxNode, depth: number, path: number[]) => void} visit
+ * @param {number} [depth]
+ * @param {number[]} [path]
+ */
 function walkAx(node, visit, depth = 0, path = []) {
     if (!node) return;
     visit(node, depth, path);
@@ -189,46 +318,58 @@ function walkAx(node, visit, depth = 0, path = []) {
     children.forEach((child, index) => walkAx(child, visit, depth + 1, [...path, index]));
 }
 
+/** @param {AxNode|null|undefined} node */
 function isInteractiveNode(node) {
     if (!node?.role) return false;
     if (DEFAULT_INTERACTIVE_ROLES.has(String(node.role))) return true;
     return node.focused === true || node.focusable === true;
 }
 
+/** @param {AxNode|null|undefined} node */
 function singleTextChild(node) {
-    const children = Array.isArray(node.children) ? node.children : [];
+    const children = Array.isArray(node?.children) ? node.children : [];
     if (children.length !== 1) return null;
     const child = children[0];
     if (child?.role !== 'text' || !child.name) return null;
     return child.name;
 }
 
+/**
+ * @param {string} value
+ * @param {number} [max]
+ */
 function truncateName(value, max = DEFAULT_MAX_NAME_CHARS) {
     const normalized = String(value || '').replace(/\s+/g, ' ').trim();
     return normalized.length > max ? `${normalized.slice(0, max)}…` : normalized;
 }
 
+/** @param {string} role */
 function sanitizeRole(role) {
     return String(role || 'generic').toLowerCase().replace(/[^a-z0-9_-]/g, '-');
 }
 
+/** @param {unknown} value */
 function quoteAxString(value) {
     return JSON.stringify(String(value || ''));
 }
 
+/** @param {unknown} value */
 function formatAttrValue(value) {
     if (typeof value === 'string') return JSON.stringify(truncateName(value, 120));
     return String(value);
 }
 
+/** @param {unknown} input */
 function hashElementSignature(input) {
     return `sha256:${createHash('sha256').update(JSON.stringify(input)).digest('hex').slice(0, 16)}`;
 }
 
+/** @param {string} role @param {string} name */
 function roleNameKey(role, name) {
     return `${String(role || 'unknown')}\u0000${String(name || '')}`;
 }
 
+/** @param {unknown} value */
 export function hashDoctorField(value) {
     return `sha256:${createHash('sha256').update(String(value)).digest('hex').slice(0, 12)}`;
 }

--- a/web-ai/ax-snapshot.mjs
+++ b/web-ai/ax-snapshot.mjs
@@ -207,7 +207,7 @@ export function summarizeSnapshotForDoctor(snapshot, { maxRefs = 8 } = {}) {
  */
 async function captureAccessibilitySnapshot(page, { interactiveOnly, rootSelector }) {
     const ax = /** @type {{ snapshot?: (opts: { interestingOnly?: boolean, root?: unknown }) => Promise<AxNode|null> } | undefined} */ (
-        /** @type {Record<string, unknown>} */ (/** @type {unknown} */ (page)).accessibility
+        /** @type {{ accessibility?: unknown } | null | undefined} */ (/** @type {unknown} */ (page))?.accessibility
     );
     if (!ax || typeof ax.snapshot !== 'function') {
         throw new WebAiError({


### PR DESCRIPTION
VERDICT-B per-file ts-check + JSDoc on web-ai/ax-snapshot.mjs (234 lines). Adds to tsconfig.checkjs-dom.json (DOM-aware sibling because imports dom-hash). 5 typedefs (AxNode/InteractiveRef/SerializeOptions/SerializeContext/WebAiSnapshot). Pure-JSDoc casts for dynamic node[attr] indexing and the runtime-only page.accessibility property (Playwright 1.58 dropped it from public types). Gates clean; npm test 473 pass / 12 skipped.