### PR TITLE
chore(strict): P14 - active-command-store.mjs annotation

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P14-active-command-store.md
+++ b/devlog/_plan/strict-migration/phases/03-P14-active-command-store.md
@@ -1,0 +1,25 @@
+# P14 — active-command-store.mjs (active command lock + lifecycle)
+
+VERDICT-B (per-file `// @ts-check` + JSDoc; no runtime change). Adds `web-ai/active-command-store.mjs` (226 lines) to `tsconfig.checkjs.json` (Node-only file).
+
+## Files
+- `web-ai/active-command-store.mjs` — `// @ts-check` + JSDoc on every export and helper.
+  - 4 typedefs: `ActiveCommandError` (`Error & { code?, cause?, command? }`), `ActiveCommandRow` (the canonical row written to `~/.browser-agent/web-ai-active-commands.json`), `ActiveCommandInput` (Partial<Row> + ttl/heartbeat/port options), `ActiveCommandStoreFile`.
+  - `Error.code` / `Error.cause` / `Error.command` mutations cast through `ActiveCommandError` (typedef-only). Pattern: `const error = /** @type {ActiveCommandError} */ (new Error(...))`.
+  - `withActiveCommandLock` and `withActiveCommand` use `@template T`.
+  - `currentCommandContext` annotated `/** @type {ActiveCommandRow|null} */`.
+  - Caught-error `.code` access uses inline JSDoc cast: `/** @type {{code?: string}} */ (error)?.code` and `/** @type {{message?: string}} */ (cause)?.message`.
+  - `normalizeActiveCommand` casts `input.commandId`/`startedAt`/`heartbeatAt`/`expiresAt` to `string` because all callers go through `registerActiveCommand`, which guarantees these via `||` defaults before normalize.
+- `tsconfig.checkjs.json` — add entry (44 → 45).
+
+## Rationale
+- File only uses Node APIs (`node:fs`, `node:path`, `node:os`) — fits checkjs.json.
+- The Error mutations are intentional metadata for downstream callers (`error.code`, `error.command`). The `ActiveCommandError` typedef formalizes the shape without changing semantics.
+- `Partial<ActiveCommandRow>` for `ActiveCommandInput` keeps the public API compatible (callers pass only some fields).
+
+## Gates
+- `npm run typecheck` — 0 errors
+- `npm run typecheck:checkjs` — 0 errors
+- `npm run typecheck:checkjs-dom` — 0 errors
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 pass / 12 skipped

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -49,7 +49,8 @@
     "web-ai/source-audit.mjs",
     "web-ai/grok-model.mjs",
     "web-ai/gemini-model.mjs",
-    "web-ai/eval-runner.mjs"
+    "web-ai/eval-runner.mjs",
+    "web-ai/active-command-store.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/active-command-store.mjs
+++ b/web-ai/active-command-store.mjs
@@ -1,13 +1,41 @@
+// @ts-check
 import { existsSync, mkdirSync, openSync, closeSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { generateSessionId } from './session-store.mjs';
+
+/**
+ * @typedef {Error & { code?: string, cause?: unknown, command?: ActiveCommandRow }} ActiveCommandError
+ *
+ * @typedef {{
+ *   commandId: string,
+ *   command: string,
+ *   provider: string,
+ *   sessionId: string|null,
+ *   targetId: string|null,
+ *   owner: string,
+ *   browserProfileKey: string,
+ *   startedAt: string,
+ *   heartbeatAt: string,
+ *   expiresAt: string,
+ *   status: string,
+ *   completedAt?: string,
+ * }} ActiveCommandRow
+ *
+ * @typedef {Partial<ActiveCommandRow> & { ttlMs?: number, heartbeatIntervalMs?: number, port?: string|number }} ActiveCommandInput
+ *
+ * @typedef {{
+ *   version: number,
+ *   commands: ActiveCommandRow[],
+ * }} ActiveCommandStoreFile
+ */
 
 const STORE_VERSION = 1;
 const LOCK_RETRY_MS = 25;
 const LOCK_RETRY_LIMIT = 200;
 const STALE_LOCK_MS = 30_000;
 const DEFAULT_TTL_MS = 2 * 60_000;
+/** @type {ActiveCommandRow|null} */
 let currentCommandContext = null;
 
 function home() {
@@ -22,6 +50,7 @@ function lockPath() {
     return `${storePath()}.lock`;
 }
 
+/** @returns {ActiveCommandStoreFile} */
 function readStore() {
     const path = storePath();
     if (!existsSync(path)) return { version: STORE_VERSION, commands: [] };
@@ -29,16 +58,17 @@ function readStore() {
         const parsed = JSON.parse(readFileSync(path, 'utf8'));
         return {
             version: Number(parsed?.version) || STORE_VERSION,
-            commands: Array.isArray(parsed?.commands) ? parsed.commands.filter(row => row?.commandId) : [],
+            commands: Array.isArray(parsed?.commands) ? parsed.commands.filter((/** @type {{commandId?: unknown}} */ row) => row?.commandId) : [],
         };
     } catch (cause) {
-        const error = new Error(`active command store unavailable: ${cause?.message || path}`);
+        const error = /** @type {ActiveCommandError} */ (new Error(`active command store unavailable: ${/** @type {{message?: string}} */ (cause)?.message || path}`));
         error.code = 'active-command.store-unavailable';
         error.cause = cause;
         throw error;
     }
 }
 
+/** @param {ActiveCommandStoreFile} store */
 function writeStore(store) {
     const path = storePath();
     mkdirSync(dirname(path), { recursive: true });
@@ -47,9 +77,15 @@ function writeStore(store) {
     renameSync(tmp, path);
 }
 
+/**
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
 export async function withActiveCommandLock(fn) {
     const path = lockPath();
     mkdirSync(dirname(path), { recursive: true });
+    /** @type {number|null} */
     let fd = null;
     let attempts = 0;
     while (attempts < LOCK_RETRY_LIMIT) {
@@ -58,7 +94,7 @@ export async function withActiveCommandLock(fn) {
             writeFileSync(fd, JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }));
             break;
         } catch (error) {
-            if (error?.code !== 'EEXIST') throw error;
+            if (/** @type {{code?: string}} */ (error)?.code !== 'EEXIST') throw error;
             attempts += 1;
             if (isStaleLock(path)) {
                 try { unlinkSync(path); } catch { /* raced */ }
@@ -76,6 +112,7 @@ export async function withActiveCommandLock(fn) {
     }
 }
 
+/** @param {string} path */
 function isStaleLock(path) {
     try {
         const parsed = JSON.parse(readFileSync(path, 'utf8'));
@@ -86,10 +123,12 @@ function isStaleLock(path) {
     }
 }
 
+/** @param {number} ms */
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/** @param {ActiveCommandInput} [input] */
 export async function registerActiveCommand(input = {}) {
     const now = new Date();
     const command = normalizeActiveCommand({
@@ -111,7 +150,7 @@ export async function registerActiveCommand(input = {}) {
                 row.commandId !== command.commandId)
             : null;
         if (targetConflict) {
-            const error = new Error(`target already owned by active command: ${targetConflict.commandId}`);
+            const error = /** @type {ActiveCommandError} */ (new Error(`target already owned by active command: ${targetConflict.commandId}`));
             error.code = 'active-command.target-owned';
             error.command = targetConflict;
             throw error;
@@ -123,6 +162,10 @@ export async function registerActiveCommand(input = {}) {
     });
 }
 
+/**
+ * @param {string} commandId
+ * @param {{ ttlMs?: number }} [options]
+ */
 export async function heartbeatActiveCommand(commandId, { ttlMs = DEFAULT_TTL_MS } = {}) {
     const now = new Date();
     return withActiveCommandLock(async () => {
@@ -139,6 +182,10 @@ export async function heartbeatActiveCommand(commandId, { ttlMs = DEFAULT_TTL_MS
     });
 }
 
+/**
+ * @param {string} commandId
+ * @param {string} [status]
+ */
 export async function releaseActiveCommand(commandId, status = 'completed') {
     return withActiveCommandLock(async () => {
         const store = readStore();
@@ -151,6 +198,9 @@ export async function releaseActiveCommand(commandId, status = 'completed') {
     });
 }
 
+/**
+ * @param {{ active?: boolean, targetId?: string, browserProfileKey?: string|number, owner?: string }} [filter]
+ */
 export async function listActiveCommands(filter = {}) {
     return withActiveCommandLock(async () => {
         const now = Date.now();
@@ -172,18 +222,28 @@ export async function listActiveCommands(filter = {}) {
     });
 }
 
+/**
+ * @param {{ targetId?: string, browserProfileKey?: string|number, owner?: string }} [filter]
+ */
 export async function activeCommandTargetIds(filter = {}) {
     const commands = await listActiveCommands({ ...filter, active: true });
     return new Set(commands.map(row => row.targetId).filter(Boolean));
 }
 
+/**
+ * @template T
+ * @param {ActiveCommandInput} input
+ * @param {(command: ActiveCommandRow) => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
 export async function withActiveCommand(input, fn) {
     if (isSameCommandTarget(currentCommandContext, input)) {
-        return fn(currentCommandContext);
+        return fn(/** @type {ActiveCommandRow} */ (currentCommandContext));
     }
     const command = await registerActiveCommand(input);
     const previousContext = currentCommandContext;
     currentCommandContext = command;
+    /** @type {NodeJS.Timeout|null} */
     let heartbeatTimer = null;
     if (input.heartbeatIntervalMs !== 0) {
         const interval = Math.max(1000, input.heartbeatIntervalMs || 15_000);
@@ -201,6 +261,10 @@ export async function withActiveCommand(input, fn) {
     }
 }
 
+/**
+ * @param {ActiveCommandRow|null} command
+ * @param {ActiveCommandInput} [input]
+ */
 function isSameCommandTarget(command, input = {}) {
     if (!command?.targetId || !input?.targetId) return false;
     const inputProfile = String(input.browserProfileKey || input.port || process.env.CDP_PORT || '9222');
@@ -209,18 +273,22 @@ function isSameCommandTarget(command, input = {}) {
         command.browserProfileKey === inputProfile;
 }
 
+/**
+ * @param {ActiveCommandInput} [input]
+ * @returns {ActiveCommandRow}
+ */
 function normalizeActiveCommand(input = {}) {
     return {
-        commandId: input.commandId,
+        commandId: /** @type {string} */ (input.commandId),
         command: input.command || 'web-ai',
         provider: input.provider || 'chatgpt',
         sessionId: input.sessionId || null,
         targetId: input.targetId || null,
         owner: input.owner || 'cli',
         browserProfileKey: String(input.browserProfileKey || input.port || process.env.CDP_PORT || '9222'),
-        startedAt: input.startedAt,
-        heartbeatAt: input.heartbeatAt,
-        expiresAt: input.expiresAt,
+        startedAt: /** @type {string} */ (input.startedAt),
+        heartbeatAt: /** @type {string} */ (input.heartbeatAt),
+        expiresAt: /** @type {string} */ (input.expiresAt),
         status: input.status || 'running',
     };
 }


### PR DESCRIPTION
VERDICT-B per-file ts-check + JSDoc on web-ai/active-command-store.mjs (226 lines). 4 typedefs (ActiveCommandError, ActiveCommandRow, ActiveCommandInput, ActiveCommandStoreFile). Error.code/.cause/.command mutations formalized via ActiveCommandError typedef cast. Gates clean; npm test 473 pass / 12 skipped.