### PR TITLE
chore(strict): P15 - chatgpt-attachments.mjs annotation

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P15-chatgpt-attachments.md
+++ b/devlog/_plan/strict-migration/phases/03-P15-chatgpt-attachments.md
@@ -1,0 +1,25 @@
+# P15 — chatgpt-attachments.mjs (preflight + live attachment)
+
+VERDICT-B (per-file `// @ts-check` + JSDoc; no runtime change). Adds `web-ai/chatgpt-attachments.mjs` (true leaf — no internal imports, only `node:path`/`node:fs` + Playwright) to `tsconfig.checkjs.json`.
+
+## Files
+- `web-ai/chatgpt-attachments.mjs` — `// @ts-check` + `/// <reference types="playwright-core" />`.
+  - Typedefs: `AttachmentFile`, `PreflightOk`, `PreflightFail`, `PreflightResult` (discriminated union on `ok`), `AttachmentSuccess`, `AttachmentFailure`, `AttachmentResult`, `AttachmentTarget`, `AttachLocalFileOptions`.
+  - JSDoc on every export and helper. `Page`/`Locator` imported from playwright-core.
+  - `Set<string>` widening on the three extension sets.
+  - `string[]` widening on `softWarnings` and `usedFallbacks` to avoid `never[]` inference.
+  - Caught-error `e.message` access uses inline JSDoc cast: `/** @type {{message?: string}} */ (e)?.message` — no `instanceof Error` runtime narrowing.
+  - `accepted.warnings` uses `|| []` — wait, this is NEW. Verified original line 102 already had `...accepted.warnings`; under typedef it's optional, so I switched to `...(accepted.warnings || [])` to keep the same runtime semantics (accepted.warnings was always defined in the original return paths, so this is a no-op runtime change).
+- `tsconfig.checkjs.json` — add entry (45 → 46).
+
+## Rationale
+- Pure leaf (no internal imports). Playwright `page` + Node fs/path only — fits checkjs.json with playwright-core reference.
+- `PreflightResult` as discriminated union lets callers narrow on `.ok`.
+- `string[]` widening matches the patterns approved in P10/P11.
+
+## Gates
+- `npm run typecheck` — 0 errors
+- `npm run typecheck:checkjs` — 0 errors
+- `npm run typecheck:checkjs-dom` — 0 errors
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 pass / 12 skipped

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -50,7 +50,8 @@
     "web-ai/grok-model.mjs",
     "web-ai/gemini-model.mjs",
     "web-ai/eval-runner.mjs",
-    "web-ai/active-command-store.mjs"
+    "web-ai/active-command-store.mjs",
+    "web-ai/chatgpt-attachments.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/chatgpt-attachments.mjs
+++ b/web-ai/chatgpt-attachments.mjs
@@ -41,7 +41,7 @@ import { statSync } from 'node:fs';
  * @property {boolean} [chipVisible]
  * @property {number} [fileCount]
  * @property {string[]} usedFallbacks
- * @property {string[]} [warnings]
+ * @property {string[]} warnings
  */
 
 /**
@@ -182,7 +182,7 @@ export async function attachLocalFileLive(page, file, options = {}) {
         chipVisible: accepted.chipVisible,
         fileCount: accepted.fileCount,
         usedFallbacks: [...usedFallbacks, ...accepted.usedFallbacks],
-        warnings: [...warnings, ...(accepted.warnings || [])],
+        warnings: [...warnings, ...accepted.warnings],
     };
 }
 

--- a/web-ai/chatgpt-attachments.mjs
+++ b/web-ai/chatgpt-attachments.mjs
@@ -1,12 +1,78 @@
+// @ts-check
+/// <reference types="playwright-core" />
 import { basename } from 'node:path';
 import { statSync } from 'node:fs';
+
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('playwright-core').Locator} Locator */
+
+/**
+ * @typedef {Object} AttachmentFile
+ * @property {string} path
+ * @property {string} basename
+ * @property {number} sizeBytes
+ */
+
+/**
+ * @typedef {Object} PreflightOk
+ * @property {true} ok
+ * @property {string[]} softWarnings
+ * @property {string} basename
+ * @property {number} sizeBytes
+ * @property {string} extension
+ */
+
+/**
+ * @typedef {Object} PreflightFail
+ * @property {false} ok
+ * @property {string} rejectedReason
+ * @property {string[]} softWarnings
+ * @property {string} basename
+ * @property {number} sizeBytes
+ * @property {string} extension
+ */
+
+/** @typedef {PreflightOk | PreflightFail} PreflightResult */
+
+/**
+ * @typedef {Object} AttachmentSuccess
+ * @property {true} ok
+ * @property {string} stage
+ * @property {boolean} [chipVisible]
+ * @property {number} [fileCount]
+ * @property {string[]} usedFallbacks
+ * @property {string[]} [warnings]
+ */
+
+/**
+ * @typedef {Object} AttachmentFailure
+ * @property {false} ok
+ * @property {string} stage
+ * @property {string} error
+ * @property {string[]} usedFallbacks
+ */
+
+/** @typedef {AttachmentSuccess | AttachmentFailure} AttachmentResult */
+
+/**
+ * @typedef {Object} AttachmentTarget
+ * @property {string} [selector]
+ */
+
+/**
+ * @typedef {Object} AttachLocalFileOptions
+ * @property {AttachmentTarget|null} [uploadTarget]
+ */
 
 const HARD_LIMIT_BYTES = 512 * 1024 * 1024;
 const IMAGE_LIMIT_BYTES = 20 * 1024 * 1024;
 const SOFT_SPREADSHEET_BYTES = 50 * 1024 * 1024;
 
+/** @type {Set<string>} */
 const UNSUPPORTED_EXTENSIONS = new Set(['.gdoc', '.gsheet', '.gslides']);
+/** @type {Set<string>} */
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.heic']);
+/** @type {Set<string>} */
 const SPREADSHEET_EXTENSIONS = new Set(['.csv', '.tsv', '.xls', '.xlsx']);
 
 export const UPLOAD_BUTTON_SELECTORS = [
@@ -45,14 +111,23 @@ const UPLOAD_PROGRESS_SELECTORS = [
     '[data-testid*="upload-progress" i]',
 ];
 
+/**
+ * @param {string} filePath
+ * @returns {AttachmentFile}
+ */
 export function fileInfoFromPath(filePath) {
     const stat = statSync(filePath);
     if (!stat.isFile()) throw new Error(`not a regular file: ${filePath}`);
     return { path: filePath, basename: basename(filePath), sizeBytes: stat.size };
 }
 
+/**
+ * @param {AttachmentFile} file
+ * @returns {PreflightResult}
+ */
 export function preflightAttachment(file) {
     const extension = extractExtension(file.basename);
+    /** @type {string[]} */
     const softWarnings = [];
     if (UNSUPPORTED_EXTENSIONS.has(extension)) {
         return { ok: false, rejectedReason: `unsupported extension: ${extension}`, softWarnings, basename: file.basename, sizeBytes: file.sizeBytes, extension };
@@ -69,8 +144,16 @@ export function preflightAttachment(file) {
     return { ok: true, softWarnings, basename: file.basename, sizeBytes: file.sizeBytes, extension };
 }
 
+/**
+ * @param {Page} page
+ * @param {AttachmentFile} file
+ * @param {AttachLocalFileOptions} [options]
+ * @returns {Promise<AttachmentResult>}
+ */
 export async function attachLocalFileLive(page, file, options = {}) {
+    /** @type {string[]} */
     const usedFallbacks = [];
+    /** @type {string[]} */
     const warnings = [];
     const preflight = preflightAttachment(file);
     if (!preflight.ok) {
@@ -89,7 +172,7 @@ export async function attachLocalFileLive(page, file, options = {}) {
     try {
         await page.locator(inputSel).first().setInputFiles(file.path, { timeout: 10_000 });
     } catch (e) {
-        return { ok: false, stage: 'attachment-upload', error: `setInputFiles failed: ${e.message}`, usedFallbacks };
+        return { ok: false, stage: 'attachment-upload', error: `setInputFiles failed: ${/** @type {{message?: string}} */ (e)?.message}`, usedFallbacks };
     }
     const accepted = await waitForAttachmentAcceptedLive(page, { timeoutMs: 45_000 });
     if (!accepted.ok) return accepted;
@@ -99,10 +182,15 @@ export async function attachLocalFileLive(page, file, options = {}) {
         chipVisible: accepted.chipVisible,
         fileCount: accepted.fileCount,
         usedFallbacks: [...usedFallbacks, ...accepted.usedFallbacks],
-        warnings: [...warnings, ...accepted.warnings],
+        warnings: [...warnings, ...(accepted.warnings || [])],
     };
 }
 
+/**
+ * @param {Page} page
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<AttachmentResult>}
+ */
 export async function waitForAttachmentAcceptedLive(page, opts = {}) {
     const deadline = Date.now() + (opts.timeoutMs || 45_000);
     while (Date.now() < deadline) {
@@ -122,6 +210,11 @@ export async function waitForAttachmentAcceptedLive(page, opts = {}) {
     return { ok: false, stage: 'attachment-upload', error: 'attachment never showed visible chip', usedFallbacks: [] };
 }
 
+/**
+ * @param {Page} page
+ * @param {AttachmentFile|null} [expectedFile]
+ * @returns {Promise<AttachmentResult>}
+ */
 export async function verifySentTurnAttachmentLive(page, expectedFile = null) {
     const turn = page.locator('[data-turn="user"], [data-message-author-role="user"]').last();
     if ((await turn.count().catch(() => 0)) === 0) {
@@ -141,6 +234,12 @@ export async function verifySentTurnAttachmentLive(page, expectedFile = null) {
     return { ok: true, stage: 'attachment-verified', chipVisible: true, fileCount: evidence, usedFallbacks: [], warnings: [] };
 }
 
+/**
+ * @param {Page} page
+ * @param {string[]} usedFallbacks
+ * @param {AttachmentTarget|null} [uploadTarget]
+ * @returns {Promise<void>}
+ */
 async function openUploadSurface(page, usedFallbacks, uploadTarget = null) {
     if (uploadTarget?.selector) {
         const clicked = await clickUploadButton(page, uploadTarget.selector);
@@ -157,11 +256,16 @@ async function openUploadSurface(page, usedFallbacks, uploadTarget = null) {
             await page.waitForTimeout(500);
             return;
         } catch (e) {
-            usedFallbacks.push(`upload-button-click-failed:${sel}:${e.message}`);
+            usedFallbacks.push(`upload-button-click-failed:${sel}:${/** @type {{message?: string}} */ (e)?.message}`);
         }
     }
 }
 
+/**
+ * @param {Page} page
+ * @param {string} selector
+ * @returns {Promise<boolean>}
+ */
 async function clickUploadButton(page, selector) {
     const loc = page.locator(selector).first();
     const visible = await loc.isVisible().catch(() => false);
@@ -177,6 +281,10 @@ async function clickUploadButton(page, selector) {
     }
 }
 
+/**
+ * @param {Page} page
+ * @returns {Promise<string|null>}
+ */
 async function findFirstFileInput(page) {
     for (const sel of FILE_INPUT_SELECTORS) {
         if ((await page.locator(sel).count().catch(() => 0)) > 0) return sel;
@@ -184,11 +292,19 @@ async function findFirstFileInput(page) {
     return null;
 }
 
+/**
+ * @param {string} name
+ * @returns {string}
+ */
 function extractExtension(name) {
     const idx = name.lastIndexOf('.');
     return idx < 0 ? '' : name.slice(idx).toLowerCase();
 }
 
+/**
+ * @param {string} name
+ * @returns {string}
+ */
 function stripExtension(name) {
     const idx = name.lastIndexOf('.');
     return idx < 0 ? name : name.slice(0, idx);


### PR DESCRIPTION
VERDICT-B per-file ts-check + JSDoc on web-ai/chatgpt-attachments.mjs (195 lines, true leaf). 9 typedefs (PreflightResult/AttachmentResult discriminated unions). Caught-error .message via inline JSDoc cast (no instanceof). Set<string> + string[] widening. Gates clean; npm test 473 pass.