### PR TITLE
chore(strict): P16 - post-action-assert.mjs annotation (DOM)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P16-post-action-assert.md
+++ b/devlog/_plan/strict-migration/phases/03-P16-post-action-assert.md
@@ -1,0 +1,24 @@
+# P16 — post-action-assert.mjs (DOM, true leaf)
+
+VERDICT-B (per-file `// @ts-check` + JSDoc; no runtime change). Adds `web-ai/post-action-assert.mjs` (110 lines, true leaf — no internal imports) to `tsconfig.checkjs-dom.json` (uses `document.querySelector`/`document.activeElement` inside `page.evaluate`).
+
+## Files
+- `web-ai/post-action-assert.mjs` — `// @ts-check` + `/// <reference types="playwright-core" />`.
+  - 8 typedefs: `ResolvedTarget`, `ScrubbedTarget`, `AssertOk`/`AssertFail`/`AssertResult` (discriminated union), `TraceRecord`, `TraceContext`, `AssertOptions`, `ClickOptions`.
+  - JSDoc on every export. `Page`/`Locator` from `playwright-core`.
+  - Caught-error `.name` access via inline cast: `/** @type {{name?: string}} */ (err)?.name`.
+  - `page.locator(target.selector)` cast: `/** @type {string} */ (target.selector)` because `ResolvedTarget.selector` is optional in typedef but call sites always pass a real selector. **No runtime change** — original code passed `target.selector` directly (Playwright treats undefined as throw at runtime; we preserve that).
+  - In `assertPostAction` the `el.textContent || el.value` accessed via `/** @type {HTMLInputElement} */ (el)` cast inside `page.evaluate` — runtime is unchanged, this is just type narrowing inside the closure.
+  - `failure: AssertFail` annotated explicitly so the `error: failure` field of TraceRecord narrows correctly.
+- `tsconfig.checkjs-dom.json` — add entry (3 → 4).
+
+## Rationale
+- DOM-aware (uses `document.*` inside `page.evaluate`), so it goes in checkjs-dom.json with DOM lib.
+- Only callers are `browser-primitives.mjs` (which is not yet annotated). This phase doesn't touch callers.
+
+## Gates
+- `npm run typecheck` — 0 errors
+- `npm run typecheck:checkjs` — 0 errors
+- `npm run typecheck:checkjs-dom` — 0 errors
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 pass / 12 skipped

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -9,6 +9,7 @@
   "include": [
     "types/**/*.d.ts",
     "web-ai/dom-hash.mjs",
+    "web-ai/post-action-assert.mjs",
     "web-ai/copy-markdown.mjs",
     "web-ai/ax-snapshot.mjs"
   ],

--- a/web-ai/post-action-assert.mjs
+++ b/web-ai/post-action-assert.mjs
@@ -1,3 +1,76 @@
+// @ts-check
+/// <reference types="playwright-core" />
+
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('playwright-core').Locator} Locator */
+
+/**
+ * @typedef {Object} ResolvedTarget
+ * @property {string} [resolution]
+ * @property {string} [source]
+ * @property {string} [ref]
+ * @property {string} [selector]
+ * @property {string} [role]
+ * @property {boolean} [contentEditable]
+ */
+
+/**
+ * @typedef {Object} ScrubbedTarget
+ * @property {string|null} resolution
+ * @property {string|null} source
+ * @property {string|null} ref
+ * @property {string|null} selector
+ * @property {string|null} role
+ */
+
+/**
+ * @typedef {Object} AssertOk
+ * @property {true} ok
+ */
+
+/**
+ * @typedef {Object} AssertFail
+ * @property {false} ok
+ * @property {string} reason
+ * @property {string} [expected]
+ * @property {string|null} [actual]
+ * @property {string} [beforeUrl]
+ * @property {string} [afterUrl]
+ */
+
+/** @typedef {AssertOk | AssertFail} AssertResult */
+
+/**
+ * @typedef {Object} TraceRecord
+ * @property {string} action
+ * @property {ScrubbedTarget|null} target
+ * @property {string} status
+ * @property {string} [errorCode]
+ * @property {AssertFail} [error]
+ */
+
+/**
+ * @typedef {Object} TraceContext
+ * @property {(record: TraceRecord) => void} record
+ */
+
+/**
+ * @typedef {Object} AssertOptions
+ * @property {string} [expectedValue]
+ * @property {string} [expectElementVisible]
+ */
+
+/**
+ * @typedef {Object} ClickOptions
+ * @property {boolean} [expectUrlChange]
+ * @property {number} [timeoutMs]
+ * @property {string} [expectElementVisible]
+ */
+
+/**
+ * @param {ResolvedTarget|null|undefined} target
+ * @returns {ScrubbedTarget|null}
+ */
 export function scrubTargetForTrace(target) {
     if (!target) return null;
     return {
@@ -9,14 +82,21 @@ export function scrubTargetForTrace(target) {
     };
 }
 
+/**
+ * @param {Page} page
+ * @param {'fill'|'click'|string} action
+ * @param {ResolvedTarget} target
+ * @param {AssertOptions} [options]
+ * @returns {Promise<AssertResult>}
+ */
 export async function assertPostAction(page, action, target, options = {}) {
     switch (action) {
         case 'fill': {
-            const locator = page.locator(target.selector);
+            const locator = page.locator(/** @type {string} */ (target.selector));
             const inputValue = typeof locator.inputValue === 'function'
                 ? await locator.inputValue().catch(() => null)
                 : null;
-            const value = inputValue ?? await locator.evaluate(el => el.textContent || el.value || '').catch(() => '');
+            const value = inputValue ?? await locator.evaluate(el => /** @type {HTMLInputElement} */ (el).textContent || /** @type {HTMLInputElement} */ (el).value || '').catch(() => '');
             const expected = options.expectedValue;
             if (expected && value !== expected) {
                 return { ok: false, reason: 'value-mismatch', expected, actual: value };
@@ -35,39 +115,57 @@ export async function assertPostAction(page, action, target, options = {}) {
     }
 }
 
+/**
+ * @param {Page} page
+ * @param {Locator} locator
+ * @param {ResolvedTarget} resolvedTarget
+ * @param {TraceContext|null|undefined} traceCtx
+ * @param {ClickOptions} [options]
+ * @returns {Promise<AssertResult>}
+ */
 export async function clickWithPostAssert(page, locator, resolvedTarget, traceCtx, options = {}) {
     const beforeUrl = page.url();
-    
+
     try {
         await locator.click();
     } catch (err) {
-        if (traceCtx) traceCtx.record({ action: 'click', target: scrubTargetForTrace(resolvedTarget), status: 'error', errorCode: err.name });
+        if (traceCtx) traceCtx.record({ action: 'click', target: scrubTargetForTrace(resolvedTarget), status: 'error', errorCode: /** @type {{name?: string}} */ (err)?.name });
         throw err;
     }
-    
+
     if (options.expectUrlChange) {
         try {
             await page.waitForURL(url => String(url) !== beforeUrl, { timeout: options.timeoutMs ?? 3000 });
         } catch {
             const afterUrl = page.url();
             if (afterUrl === beforeUrl) {
+                /** @type {AssertFail} */
                 const failure = { ok: false, reason: 'url-unchanged', beforeUrl, afterUrl };
                 if (traceCtx) traceCtx.record({ action: 'click', target: scrubTargetForTrace(resolvedTarget), status: 'false-heal', error: failure });
                 return failure;
             }
         }
     }
-    
+
     const assertion = await assertPostAction(page, 'click', resolvedTarget, options);
     if (!assertion.ok) {
         if (traceCtx) traceCtx.record({ action: 'click', target: scrubTargetForTrace(resolvedTarget), status: 'false-heal', error: assertion });
         return assertion;
     }
-    
+
     if (traceCtx) traceCtx.record({ action: 'click', target: scrubTargetForTrace(resolvedTarget), status: 'ok' });
     return { ok: true };
 }
 
+/**
+ * @param {Page} page
+ * @param {Locator} locator
+ * @param {ResolvedTarget} resolvedTarget
+ * @param {string} value
+ * @param {TraceContext|null|undefined} traceCtx
+ * @param {AssertOptions} [options]
+ * @returns {Promise<AssertResult>}
+ */
 export async function fillWithPostAssert(page, locator, resolvedTarget, value, traceCtx, options = {}) {
     try {
         await locator.fill(value);
@@ -90,21 +188,21 @@ export async function fillWithPostAssert(page, locator, resolvedTarget, value, t
                 await page.keyboard.press(`${mod}+a`);
                 await page.keyboard.insertText(value);
             } catch (kbErr) {
-                if (traceCtx) traceCtx.record({ action: 'fill', target: scrubTargetForTrace(resolvedTarget), status: 'error', errorCode: kbErr.name });
+                if (traceCtx) traceCtx.record({ action: 'fill', target: scrubTargetForTrace(resolvedTarget), status: 'error', errorCode: /** @type {{name?: string}} */ (kbErr)?.name });
                 throw kbErr;
             }
         } else {
-            if (traceCtx) traceCtx.record({ action: 'fill', target: scrubTargetForTrace(resolvedTarget), status: 'error', errorCode: fillErr.name });
+            if (traceCtx) traceCtx.record({ action: 'fill', target: scrubTargetForTrace(resolvedTarget), status: 'error', errorCode: /** @type {{name?: string}} */ (fillErr)?.name });
             throw fillErr;
         }
     }
-    
+
     const assertion = await assertPostAction(page, 'fill', resolvedTarget, { expectedValue: value });
     if (!assertion.ok) {
         if (traceCtx) traceCtx.record({ action: 'fill', target: scrubTargetForTrace(resolvedTarget), status: 'false-heal', error: assertion });
         return assertion;
     }
-    
+
     if (traceCtx) traceCtx.record({ action: 'fill', target: scrubTargetForTrace(resolvedTarget), status: 'ok' });
     return { ok: true };
 }


### PR DESCRIPTION
VERDICT-B per-file ts-check + JSDoc on web-ai/post-action-assert.mjs (110 lines, true leaf). DOM-aware (document.querySelector/activeElement inside page.evaluate) -> checkjs-dom.json. 8 typedefs incl. AssertResult discriminated union. No runtime change. Gates clean; npm test 473 pass.