### PR TITLE
chore(strict): P17 - browser-primitives.mjs annotation (DOM)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P17-browser-primitives.md
+++ b/devlog/_plan/strict-migration/phases/03-P17-browser-primitives.md
@@ -1,0 +1,24 @@
+# P17 — browser-primitives.mjs (DOM)
+
+VERDICT-B (per-file `// @ts-check` + JSDoc; no runtime change). Adds `web-ai/browser-primitives.mjs` (167 lines). Imports post-action-assert (annotated in P16). DOM-aware via `document.querySelectorAll` and `globalThis.getComputedStyle` inside `page.evaluate`.
+
+## Files
+- `web-ai/browser-primitives.mjs`:
+  - `// @ts-check` + `/// <reference types="playwright-core" />`.
+  - 7 typedefs: `BrowserCapabilityErrorInput`, `VisibleCandidate`, `FindVisibleOptions`, `TextBaseline`, `StableTextOptions`, `StableTextResult`. Plus reuse of `ResolvedTarget` and `TraceContext` via `import('./post-action-assert.mjs')`.
+  - `BrowserCapabilityError` class — JSDoc on constructor + class-field type annotations for `capabilityId`/`stage`.
+  - `ActionTranscript` class — `string[]` annotations on `warnings` and `usedFallbacks` class fields.
+  - `string[]`/`string|undefined`/`number|null` widening on local vars.
+  - Inside `locator.evaluate(node => ...)` and `page.evaluate(innerSelectors => ...)` closures: `Element`/`HTMLElement` casts on `node`/`el` so `getBoundingClientRect`/`innerText` typecheck. NO runtime change.
+- `tsconfig.checkjs-dom.json` — add entry (4 → 5).
+
+## Rationale
+- Post-action-assert was the only internal dep; now annotated. Pulls in `ResolvedTarget`/`TraceContext` typedefs.
+- DOM-aware closures inside `page.evaluate` need DOM lib for `document`/`globalThis.getComputedStyle`.
+
+## Gates
+- `npm run typecheck` — 0 errors
+- `npm run typecheck:checkjs` — 0 errors
+- `npm run typecheck:checkjs-dom` — 0 errors
+- `npm run smoke:bins` — both bins ok
+- `npm test` — 473 pass / 12 skipped

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -10,6 +10,7 @@
     "types/**/*.d.ts",
     "web-ai/dom-hash.mjs",
     "web-ai/post-action-assert.mjs",
+    "web-ai/browser-primitives.mjs",
     "web-ai/copy-markdown.mjs",
     "web-ai/ax-snapshot.mjs"
   ],

--- a/web-ai/browser-primitives.mjs
+++ b/web-ai/browser-primitives.mjs
@@ -1,21 +1,44 @@
+// @ts-check
+/// <reference types="playwright-core" />
+
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('playwright-core').Locator} Locator */
+
+/**
+ * @typedef {Object} BrowserCapabilityErrorInput
+ * @property {string} [capabilityId]
+ * @property {string} [stage]
+ * @property {boolean} [mutationAllowed]
+ */
+
 export class BrowserCapabilityError extends Error {
+    /**
+     * @param {string} message
+     * @param {BrowserCapabilityErrorInput} input
+     */
     constructor(message, input) {
         super(message);
         this.name = 'BrowserCapabilityError';
+        /** @type {string|undefined} */
         this.capabilityId = input.capabilityId;
+        /** @type {string|undefined} */
         this.stage = input.stage;
         this.mutationAllowed = input.mutationAllowed === true;
     }
 }
 
 export class ActionTranscript {
+    /** @type {string[]} */
     warnings = [];
+    /** @type {string[]} */
     usedFallbacks = [];
 
+    /** @param {string} message */
     warn(message) {
         this.warnings.push(message);
     }
 
+    /** @param {string} name */
     fallback(name) {
         this.usedFallbacks.push(name);
     }
@@ -28,10 +51,32 @@ export class ActionTranscript {
     }
 }
 
+/**
+ * @typedef {Object} VisibleCandidate
+ * @property {string} selector
+ * @property {number} index
+ * @property {Locator} locator
+ * @property {boolean} visible
+ */
+
+/**
+ * @typedef {Object} FindVisibleOptions
+ * @property {number} [timeoutMs]
+ * @property {number} [pollIntervalMs]
+ * @property {boolean} [allowFirstCandidateFallback]
+ */
+
+/**
+ * @param {Page} page
+ * @param {string[]} selectors
+ * @param {FindVisibleOptions} [options]
+ * @returns {Promise<VisibleCandidate|null>}
+ */
 export async function findVisibleCandidate(page, selectors, options = {}) {
     const timeoutMs = Math.max(0, options.timeoutMs ?? 0);
     const pollIntervalMs = Math.max(25, options.pollIntervalMs ?? 250);
     const deadline = Date.now() + timeoutMs;
+    /** @type {VisibleCandidate|null} */
     let firstCandidate = null;
 
     do {
@@ -41,6 +86,7 @@ export async function findVisibleCandidate(page, selectors, options = {}) {
             for (let index = 0; index < count; index += 1) {
                 const locator = typeof baseLocator.nth === 'function' ? baseLocator.nth(index) : baseLocator.first();
                 const visible = await isLocatorVisible(locator);
+                /** @type {VisibleCandidate} */
                 const candidate = { selector, index, locator, visible };
                 firstCandidate ??= candidate;
                 if (visible) return candidate;
@@ -53,6 +99,20 @@ export async function findVisibleCandidate(page, selectors, options = {}) {
     return options.allowFirstCandidateFallback ? firstCandidate : null;
 }
 
+/**
+ * @typedef {Object} TextBaseline
+ * @property {string[]} selectors
+ * @property {string[]} texts
+ * @property {number} count
+ * @property {string} textHash
+ * @property {string} capturedAt
+ */
+
+/**
+ * @param {Page} page
+ * @param {string[]} selectors
+ * @returns {Promise<TextBaseline>}
+ */
 export async function captureTextBaseline(page, selectors) {
     const texts = await readTexts(page, selectors);
     return {
@@ -64,14 +124,40 @@ export async function captureTextBaseline(page, selectors) {
     };
 }
 
+/**
+ * @typedef {Object} StableTextOptions
+ * @property {number} timeoutMs
+ * @property {number} [stableWindowMs]
+ * @property {number} [pollIntervalMs]
+ * @property {number} [minCount]
+ */
+
+/**
+ * @typedef {Object} StableTextResult
+ * @property {boolean} ok
+ * @property {TextBaseline} baseline
+ * @property {string|undefined} latestText
+ * @property {string[]} warnings
+ */
+
+/**
+ * @param {Page} page
+ * @param {string[]} selectors
+ * @param {TextBaseline} baseline
+ * @param {StableTextOptions} options
+ * @returns {Promise<StableTextResult>}
+ */
 export async function waitForStableTextAfterBaseline(page, selectors, baseline, options) {
     const timeoutMs = Math.max(1, options.timeoutMs);
     const stableWindowMs = Math.max(100, options.stableWindowMs ?? 1000);
     const pollIntervalMs = Math.max(25, options.pollIntervalMs ?? 250);
     const minCount = Math.max(baseline.count + 1, options.minCount ?? 0);
     const deadline = Date.now() + timeoutMs;
+    /** @type {string[]} */
     const warnings = [];
+    /** @type {string|undefined} */
     let stableText;
+    /** @type {number|null} */
     let stableSince = null;
 
     while (Date.now() < deadline) {
@@ -96,25 +182,34 @@ export async function waitForStableTextAfterBaseline(page, selectors, baseline, 
     return { ok: false, baseline, latestText: stableText, warnings };
 }
 
+/**
+ * @param {Locator} locator
+ * @returns {Promise<boolean>}
+ */
 export async function isLocatorVisible(locator) {
     const waited = await locator.waitFor?.({ state: 'visible', timeout: 500 }).then(() => true).catch(() => false);
     if (waited) return true;
     const box = await locator.boundingBox?.().catch(() => null);
     if (box && box.width > 0 && box.height > 0) return true;
     return Boolean(await locator.evaluate?.((node) => {
-        if (!node || typeof node.getBoundingClientRect !== 'function') return false;
-        const rect = node.getBoundingClientRect();
+        if (!node || typeof /** @type {Element} */ (node).getBoundingClientRect !== 'function') return false;
+        const rect = /** @type {Element} */ (node).getBoundingClientRect();
         if (rect.width <= 0 || rect.height <= 0) return false;
-        const style = globalThis.getComputedStyle?.(node);
+        const style = globalThis.getComputedStyle?.(/** @type {Element} */ (node));
         return !style || (style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0');
     }).catch(() => false));
 }
 
+/**
+ * @param {Page} page
+ * @param {string[]} selectors
+ * @returns {Promise<string[]>}
+ */
 async function readTexts(page, selectors) {
     const evaluated = await page.evaluate?.((innerSelectors) => {
         for (const selector of innerSelectors) {
             const texts = Array.from(document.querySelectorAll(selector))
-                .map((el) => String(el.innerText || el.textContent || '').trim())
+                .map((el) => String(/** @type {HTMLElement} */ (el).innerText || el.textContent || '').trim())
                 .filter(Boolean);
             if (texts.length) return texts;
         }
@@ -124,6 +219,7 @@ async function readTexts(page, selectors) {
 
     for (const selector of selectors) {
         const locators = await page.locator(selector).all().catch(() => []);
+        /** @type {string[]} */
         const texts = [];
         for (const locator of locators) {
             const text = String(await locator.innerText?.().catch(() => '') || '').trim();
@@ -134,6 +230,10 @@ async function readTexts(page, selectors) {
     return [];
 }
 
+/**
+ * @param {string[]} texts
+ * @returns {string}
+ */
 function hashTexts(texts) {
     let hash = 2166136261;
     for (const text of texts) {
@@ -147,14 +247,33 @@ function hashTexts(texts) {
 
 import { clickWithPostAssert, fillWithPostAssert } from './post-action-assert.mjs';
 
+/** @typedef {import('./post-action-assert.mjs').ResolvedTarget} ResolvedTarget */
+/** @typedef {import('./post-action-assert.mjs').TraceContext} TraceContext */
+
+/**
+ * @param {Page} page
+ * @param {Locator} locator
+ * @param {ResolvedTarget} resolvedTarget
+ * @param {TraceContext|null|undefined} traceCtx
+ */
 export async function clickResolvedTarget(page, locator, resolvedTarget, traceCtx) {
     return clickWithPostAssert(page, locator, resolvedTarget, traceCtx);
 }
 
+/**
+ * @param {Page} page
+ * @param {Locator} locator
+ * @param {ResolvedTarget} resolvedTarget
+ * @param {string} value
+ * @param {TraceContext|null|undefined} traceCtx
+ */
 export async function fillResolvedTarget(page, locator, resolvedTarget, value, traceCtx) {
     return fillWithPostAssert(page, locator, resolvedTarget, value, traceCtx);
 }
 
+/**
+ * @param {ResolvedTarget|null|undefined} target
+ */
 function scrubTargetForTrace(target) {
     if (!target) return null;
     return {


### PR DESCRIPTION
VERDICT-B per-file ts-check + JSDoc on web-ai/browser-primitives.mjs (167 lines). DOM-aware (document.querySelectorAll + getComputedStyle in page.evaluate) -> checkjs-dom.json. Imports post-action-assert (P16). 7 typedefs. ResolvedTarget/TraceContext reused via import(). No runtime change. Gates clean; npm test 473 pass.