### PR TITLE
chore(strict-p20): annotate web-ai/tab-pool.mjs

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P20-tab-pool.md
+++ b/devlog/_plan/strict-migration/phases/03-P20-tab-pool.md
@@ -1,0 +1,16 @@
+# P20 — web-ai/tab-pool.mjs
+
+VERDICT-B per-file `// @ts-check` annotation. Pure compatibility shim over `tab-lease-store.mjs` (already P19-annotated). 56 lines, no internal dependencies other than tab-lease-store.
+
+## Annotations
+- `PoolTabOptions`, `GetPooledTabOptions`, `CleanupPoolTabsOptions` typedefs (loose Partial-style — every field optional, matching the existing runtime defaults).
+- JSDoc on all 5 exported functions (`poolTab`, `getPooledTab`, `unpoolTab`, `cleanupPoolTabs`, `getPoolStats` — the last needs none).
+
+## Runtime
+Zero runtime changes. No `Boolean(...)`, `String(...)`, `Number(...)`, no `instanceof Error` narrowing, no `|| ''`/`|| []`/`|| {}` fallbacks added.
+
+## Gates
+- `npm run typecheck` ✓
+- `npx tsc --noEmit -p tsconfig.checkjs.json` ✓ (49 entries)
+- `npm run smoke:bins` ✓
+- `npm test` ✓

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -53,7 +53,8 @@
     "web-ai/active-command-store.mjs",
     "web-ai/chatgpt-attachments.mjs",
     "skills/browser/tab-manager.mjs",
-    "web-ai/tab-lease-store.mjs"
+    "web-ai/tab-lease-store.mjs",
+    "web-ai/tab-pool.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/tab-pool.mjs
+++ b/web-ai/tab-pool.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Tab Pool compatibility layer.
  *
@@ -12,6 +13,39 @@ import {
     removeLease,
 } from './tab-lease-store.mjs';
 
+/**
+ * @typedef {Object} PoolTabOptions
+ * @property {string} [owner]
+ * @property {string} [sessionType]
+ * @property {string|null} [sessionId]
+ * @property {number} [port]
+ * @property {string} [browserProfileKey]
+ * @property {number} [maxPerKey]
+ * @property {number} [globalMax]
+ * @property {number} [ttlMs]
+ */
+
+/**
+ * @typedef {Object} GetPooledTabOptions
+ * @property {string} [owner]
+ * @property {string} [sessionType]
+ * @property {string} [origin]
+ * @property {string} [url]
+ * @property {string} [browserProfileKey]
+ */
+
+/**
+ * @typedef {Object} CleanupPoolTabsOptions
+ * @property {number} [maxAgeMs]
+ * @property {string} [browserProfileKey]
+ */
+
+/**
+ * @param {string} vendor
+ * @param {string} targetId
+ * @param {string|null|undefined} url
+ * @param {PoolTabOptions} [options]
+ */
 export async function poolTab(vendor, targetId, url, options = {}) {
     if (!vendor || !targetId) return null;
     return releaseCompletedLease(options.port || 9222, {
@@ -29,6 +63,11 @@ export async function poolTab(vendor, targetId, url, options = {}) {
     });
 }
 
+/**
+ * @param {number} port
+ * @param {string} vendor
+ * @param {GetPooledTabOptions} [options]
+ */
 export async function getPooledTab(port, vendor, options = {}) {
     const lease = await checkoutPooledLease(port, {
         owner: options.owner || 'web-ai',
@@ -42,11 +81,19 @@ export async function getPooledTab(port, vendor, options = {}) {
     return lease ? { targetId: lease.targetId, url: lease.url } : null;
 }
 
+/**
+ * @param {string} vendor
+ * @param {string} targetId
+ */
 export async function unpoolTab(vendor, targetId) {
     void vendor;
     await removeLease(targetId);
 }
 
+/**
+ * @param {number} port
+ * @param {CleanupPoolTabsOptions} [options]
+ */
 export async function cleanupPoolTabs(port, options = {}) {
     return cleanupLeasedTabs(port, options);
 }


### PR DESCRIPTION
VERDICT-B per-file @ts-check + JSDoc on tab-pool compatibility shim. Depends only on tab-lease-store (P19-annotated). All gates green.