### PR TITLE
chore(strict): P27 tab-lifecycle ts-check + typedefs

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P27-tab-lifecycle.md
+++ b/devlog/_plan/strict-migration/phases/03-P27-tab-lifecycle.md
@@ -1,0 +1,20 @@
+#  skills/browser/tab-lifecycle.mjsP27 
+
+VERDICT-B per-file ts-check on 190-line tab lifecycle module. All deps already checked (tab-manager, session, tab-lease-store, active-command-store).
+
+## Changes
+- Add `// @ts-check`
+- Reuse `ManagedTabRow` and `Lease` via `import('...')` typedefs.
+- New typedefs: CleanupTab (extends ManagedTabRow), SelectTabsOptions, SelectProviderOptions, CleanupOptions, CleanupSummary.
+- JSDoc on 8 exports + 2 helpers.
+- `Readonly<Record<string,string>>` for PROVIDER_ORIGINS.
+- `Set<string>` annotation on pinnedTabs and activeSessionTargetIds.
+- `Set<string | null>` for `activeCommandTargetIds` to match `activeCommandTargetIds()` return shape.
+- Inline cast `/** @type {string} */ (vendor)` in PROVIDER_ORIGINS lookup; the `if (!origin) return [];` guards a runtime-equivalent path.
+- `await listLeases().catch(() => /** @type { comment-only cast on the existing fallback array.Lease[]} */ ([]))` 
+
+## Runtime invariants
+- No `Boolean(...)` wrappers added.
+- No new `?.` introduced.
+ number` keeps the same `String(value || '').trim()` pipeline.
+- Append-only tsconfig.checkjs.json entry: `skills/browser/tab-lifecycle.mjs`.

--- a/skills/browser/tab-lifecycle.mjs
+++ b/skills/browser/tab-lifecycle.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Tab Lifecycle — Enforce MAX_TABS limit and idle timeout.
  */
@@ -6,28 +7,47 @@ import { listSessions } from '../../web-ai/session.mjs';
 import { listLeases } from '../../web-ai/tab-lease-store.mjs';
 import { activeCommandTargetIds } from '../../web-ai/active-command-store.mjs';
 
+/** @typedef {import('./tab-manager.mjs').ManagedTabRow} ManagedTabRow */
+/** @typedef {import('../../web-ai/tab-lease-store.mjs').Lease} Lease */
+
+/**
+ * @typedef {ManagedTabRow & { cleanupReason?: string, vendor?: string }} CleanupTab
+ */
+
 const MAX_TABS = parseInt(process.env.AGBROWSE_MAX_TABS || '10', 10);
 const IDLE_TIMEOUT_MS = parseDuration(process.env.AGBROWSE_TAB_IDLE || '30m');
+/** @type {Readonly<Record<string, string>>} */
 const PROVIDER_ORIGINS = {
     chatgpt: 'https://chatgpt.com',
     gemini: 'https://gemini.google.com',
     grok: 'https://grok.com',
 };
 
-const pinnedTabs = new Set(); // targetIds that should never auto-close
+/** @type {Set<string>} targetIds that should never auto-close */
+const pinnedTabs = new Set();
 
+/** @param {string} targetId */
 export function pinTab(targetId) {
     pinnedTabs.add(targetId);
 }
 
+/** @param {string} targetId */
 export function unpinTab(targetId) {
     pinnedTabs.delete(targetId);
 }
 
+/**
+ * @param {string} targetId
+ * @returns {boolean}
+ */
 export function isPinned(targetId) {
     return pinnedTabs.has(targetId);
 }
 
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
 export function parseDuration(value) {
     const match = /^(\d+)\s*(ms|s|m|h)?$/i.exec(String(value || '').trim());
     if (!match) return 30 * 60 * 1000;
@@ -37,6 +57,23 @@ export function parseDuration(value) {
     return n * factor;
 }
 
+/**
+ * @typedef {Object} SelectTabsOptions
+ * @property {ManagedTabRow[]} [tabs]
+ * @property {Set<string>} [activeSessionTargetIds]
+ * @property {Set<string | null>} [activeCommandTargetIds]
+ * @property {Set<string>} [pinnedTargetIds]
+ * @property {number} [now]
+ * @property {number} [idleTimeoutMs]
+ * @property {number} [maxTabs]
+ * @property {boolean} [includeUntracked]
+ * @property {Map<string, Lease> | null} [leaseByTargetId]
+ */
+
+/**
+ * @param {SelectTabsOptions} [opts]
+ * @returns {CleanupTab[]}
+ */
 export function selectTabsForCleanup({
     tabs,
     activeSessionTargetIds = new Set(),
@@ -48,6 +85,7 @@ export function selectTabsForCleanup({
     includeUntracked = false,
     leaseByTargetId = null,
 } = {}) {
+    /** @type {Map<string, CleanupTab>} */
     const selected = new Map();
     const closeable = (tabs || []).filter(tab =>
         tab?.targetId &&
@@ -91,6 +129,20 @@ export function selectTabsForCleanup({
     return Array.from(selected.values());
 }
 
+/**
+ * @typedef {Object} SelectProviderOptions
+ * @property {ManagedTabRow[]} [tabs]
+ * @property {string} [vendor]
+ * @property {number} [keep]
+ * @property {Set<string>} [activeSessionTargetIds]
+ * @property {Set<string | null>} [activeCommandTargetIds]
+ * @property {Set<string>} [pinnedTargetIds]
+ */
+
+/**
+ * @param {SelectProviderOptions} [opts]
+ * @returns {CleanupTab[]}
+ */
 export function selectProviderTabsForCleanup({
     tabs,
     vendor,
@@ -99,7 +151,7 @@ export function selectProviderTabsForCleanup({
     activeCommandTargetIds: activeCommandTargets = new Set(),
     pinnedTargetIds = new Set(),
 } = {}) {
-    const origin = PROVIDER_ORIGINS[vendor];
+    const origin = PROVIDER_ORIGINS[/** @type {string} */ (vendor)];
     if (!origin) return [];
     const keepCount = Math.max(0, Number.isFinite(Number(keep)) ? Number(keep) : 1);
     return (tabs || [])
@@ -114,6 +166,12 @@ export function selectProviderTabsForCleanup({
         .map(tab => ({ ...tab, cleanupReason: 'provider-overflow', vendor }));
 }
 
+/**
+ * @param {ManagedTabRow} tab
+ * @param {Map<string, Lease> | null | undefined} leaseByTargetId
+ * @param {boolean} includeUntracked
+ * @returns {boolean}
+ */
 function isCloseableByOwnership(tab, leaseByTargetId, includeUntracked) {
     if (!leaseByTargetId) return true;
     const lease = leaseByTargetId.get(tab.targetId);
@@ -123,17 +181,37 @@ function isCloseableByOwnership(tab, leaseByTargetId, includeUntracked) {
 }
 
 /**
+ * @typedef {Object} CleanupOptions
+ * @property {number} [now]
+ * @property {number} [idleTimeoutMs]
+ * @property {number} [maxTabs]
+ * @property {boolean} [includeUntracked]
+ * @property {string} [provider]
+ * @property {number} [keepProviderTabs]
+ */
+
+/**
+ * @typedef {Object} CleanupSummary
+ * @property {number} closed
+ * @property {number} idleClosed
+ * @property {number} limitClosed
+ * @property {number} untrackedClosed
+ * @property {number} providerClosed
+ */
+
+/**
  * Enforce MAX_TABS limit and idle timeout. Closes oldest non-pinned, non-active-session tabs.
  * @param {number} port - CDP port
- * @param {Object} opts
- * @returns {Promise<{closed: number, idleClosed: number, limitClosed: number}>}
+ * @param {CleanupOptions} [opts]
+ * @returns {Promise<CleanupSummary>}
  */
 export async function cleanupIdleTabs(port, opts = {}) {
     const tabs = await listManagedTabs(port);
     const now = opts.now || Date.now();
-    const leases = await listLeases().catch(() => []);
+    const leases = await listLeases().catch(() => /** @type {Lease[]} */ ([]));
     const leaseByTargetId = new Map(leases.map(lease => [lease.targetId, lease]));
 
+    /** @type {Set<string>} */
     const activeSessionTargetIds = new Set();
     for (const session of listSessions({ active: true })) {
         if (session.targetId) activeSessionTargetIds.add(session.targetId);
@@ -181,6 +259,10 @@ export async function cleanupIdleTabs(port, opts = {}) {
     return summary;
 }
 
+/**
+ * @param {string} [url]
+ * @returns {string | null}
+ */
 function providerOriginFromUrl(url = '') {
     try {
         return new URL(url).origin;

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -60,7 +60,8 @@
     "skills/browser/tab-monitor.mjs",
     "web-ai/tab-finalizer.mjs",
     "skills/browser/skill-install.mjs",
-    "web-ai/tab-recovery.mjs"
+    "web-ai/tab-recovery.mjs",
+    "skills/browser/tab-lifecycle.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
VERDICT-B per-file ts-check on skills/browser/tab-lifecycle.mjs (190 lines). All deps already checked. No runtime change.

- Add // @ts-check
- Typedefs: CleanupTab, SelectTabsOptions, SelectProviderOptions, CleanupOptions, CleanupSummary
- Reuse ManagedTabRow / Lease via import() types
- Readonly<Record<string,string>> on PROVIDER_ORIGINS
- Append tab-lifecycle.mjs to tsconfig.checkjs.json

Gates: tsc -p tsconfig.checkjs.json OK, tsc --noEmit OK, check:strict-baseline OK