### PR TITLE
chore(strict): P30 vendor-editor-contract ts-check + typedefs (DOM tsconfig)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P30-vendor-editor-contract.md
+++ b/devlog/_plan/strict-migration/phases/03-P30-vendor-editor-contract.md
@@ -1,0 +1,15 @@
+#  web-ai/vendor-editor-contract.mjs (DOM tsconfig)P30 
+
+VERDICT-B per-file ts-check on the 116-line vendor-editor contract module. All transitive deps already checked: chatgpt-composer (DOM, P29), copy-markdown (DOM), chatgpt-model (DOM, P28), chatgpt-attachments (P22). Goes into `tsconfig.checkjs-dom.json` because it imports from DOM-checked files.
+
+## Changes
+- Add `// @ts-check`
+- Re-import `ComposerOptions`/`SubmitResult` from chatgpt-composer.mjs as JSDoc typedefs.
+- Define VendorName, SemanticTarget, EditorContract, EditorAdapter, EditorAdapterBaseline typedefs.
+- JSDoc on 3 exports: createChatGptEditorAdapter, editorContractForVendor, semanticTargetsForVendor.
+- Append `web-ai/vendor-editor-contract.mjs` to `tsconfig.checkjs-dom.json`.
+
+## Runtime invariants
+- No new `?.` / `??` / Boolean/String/Number wrappers.
+- No fallback values added or removed.
+- Control flow byte-identical: only added `// @ts-check` and JSDoc comments.

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -14,7 +14,8 @@
     "web-ai/copy-markdown.mjs",
     "web-ai/ax-snapshot.mjs",
     "web-ai/chatgpt-model.mjs",
-    "web-ai/chatgpt-composer.mjs"
+    "web-ai/chatgpt-composer.mjs",
+    "web-ai/vendor-editor-contract.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/vendor-editor-contract.mjs
+++ b/web-ai/vendor-editor-contract.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import {
     INPUT_SELECTORS as CHATGPT_INPUT_SELECTORS,
     SEND_BUTTON_SELECTORS as CHATGPT_SEND_BUTTON_SELECTORS,
@@ -10,6 +11,49 @@ import { CHATGPT_COPY_SELECTORS, GEMINI_COPY_SELECTORS, GROK_COPY_SELECTORS } fr
 import { CHATGPT_MODEL_SELECTOR_BUTTONS } from './chatgpt-model.mjs';
 import { UPLOAD_BUTTON_SELECTORS as CHATGPT_UPLOAD_BUTTON_SELECTORS } from './chatgpt-attachments.mjs';
 
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('./chatgpt-composer.mjs').ComposerOptions} ComposerOptions */
+/** @typedef {import('./chatgpt-composer.mjs').SubmitResult} SubmitResult */
+
+/**
+ * @typedef {Object} EditorAdapterBaseline
+ * @property {number} turnsCount
+ */
+
+/**
+ * @typedef {Object} EditorAdapter
+ * @property {'chatgpt'} vendor
+ * @property {() => Promise<void>} waitForReady
+ * @property {() => Promise<EditorAdapterBaseline>} getCommitBaseline
+ * @property {(text: string) => Promise<void>} insertPrompt
+ * @property {(submitOptions?: ComposerOptions) => Promise<SubmitResult>} submitPrompt
+ * @property {(prompt: string, baseline?: Partial<EditorAdapterBaseline>) => Promise<{ turnsCount: number }>} verifyPromptCommitted
+ */
+
+/**
+ * @typedef {'chatgpt' | 'gemini' | 'grok'} VendorName
+ */
+
+/**
+ * @typedef {Object} SemanticTarget
+ * @property {readonly string[]} roles
+ * @property {readonly RegExp[]} [names]
+ * @property {readonly RegExp[]} [excludeNames]
+ * @property {readonly string[]} cssFallbacks
+ * @property {boolean} [required]
+ */
+
+/**
+ * @typedef {Object} EditorContract
+ * @property {VendorName} vendor
+ * @property {Readonly<Record<string, SemanticTarget>>} semanticTargets
+ */
+
+/**
+ * @param {Page} page
+ * @param {ComposerOptions} [options]
+ * @returns {EditorAdapter}
+ */
 export function createChatGptEditorAdapter(page, options = {}) {
     return {
         vendor: 'chatgpt',
@@ -107,10 +151,18 @@ export const EDITOR_CONTRACT_BY_VENDOR = Object.freeze({
     grok: GROK_EDITOR_CONTRACT,
 });
 
+/**
+ * @param {VendorName} [vendor]
+ * @returns {EditorContract}
+ */
 export function editorContractForVendor(vendor = 'chatgpt') {
     return EDITOR_CONTRACT_BY_VENDOR[vendor] || CHATGPT_EDITOR_CONTRACT;
 }
 
+/**
+ * @param {VendorName} [vendor]
+ * @returns {Readonly<Record<string, SemanticTarget>>}
+ */
 export function semanticTargetsForVendor(vendor = 'chatgpt') {
     return editorContractForVendor(vendor).semanticTargets;
 }


### PR DESCRIPTION
VERDICT-B per-file ts-check on web-ai/vendor-editor-contract.mjs (116 lines). All transitive deps already checked: chatgpt-composer (DOM, P29), copy-markdown (DOM), chatgpt-model (DOM, P28), chatgpt-attachments (P22). Goes into tsconfig.checkjs-dom.json.

Changes: // @ts-check, re-imported ComposerOptions/SubmitResult typedefs, VendorName/SemanticTarget/EditorContract/EditorAdapter/EditorAdapterBaseline typedefs, JSDoc on 3 exports.

No runtime change: only added // @ts-check and JSDoc comments. Control flow byte-identical.

Gates: tsc -p tsconfig.checkjs-dom.json OK, tsc -p tsconfig.checkjs.json OK, tsc --noEmit OK, check:strict-baseline OK.
