### PR TITLE
chore(strict): P31 contract-audit ts-check + typedefs (DOM tsconfig)

### DIFF
--- a/devlog/_plan/strict-migration/phases/03-P31-contract-audit.md
+++ b/devlog/_plan/strict-migration/phases/03-P31-contract-audit.md
@@ -1,0 +1,16 @@
+#  web-ai/contract-audit.mjs (DOM tsconfig)P31 
+
+VERDICT-B per-file ts-check on the 30-line contract audit module. Both deps already DOM-checked: vendor-editor-contract (P30), ax-snapshot.
+
+## Changes
+- Add `// @ts-check`
+- Typedefs: AuditDrift, AuditResult; reuse VendorName from vendor-editor-contract.
+- JSDoc on the single export `auditContractAgainstSnapshot`.
+- `/** @type {AuditDrift[]} */` annotation on `drifts` array.
+- `/** @type {any} */ (snapshot.refs).filter(...)`  `WebAiSnapshot.refs` is typed as `Record<string, InteractiveRef>` (no `.filter` method). The original code calls `.filter` on it; this is a pre-existing semantic mismatch. VERDICT-B preserves the runtime call exactly via JSDoc-only `any` cast.cast 
+- Append `web-ai/contract-audit.mjs` to `tsconfig.checkjs-dom.json`.
+
+## Runtime invariants
+- No new `?.` / `??` introduced.
+- No new wrappers, no fallback values added or removed.
+- Control flow byte-identical: only added `// @ts-check`, JSDoc comments, and JSDoc-only inline casts.

--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -15,7 +15,8 @@
     "web-ai/ax-snapshot.mjs",
     "web-ai/chatgpt-model.mjs",
     "web-ai/chatgpt-composer.mjs",
-    "web-ai/vendor-editor-contract.mjs"
+    "web-ai/vendor-editor-contract.mjs",
+    "web-ai/contract-audit.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/contract-audit.mjs
+++ b/web-ai/contract-audit.mjs
@@ -1,13 +1,40 @@
+// @ts-check
 import { editorContractForVendor } from './vendor-editor-contract.mjs';
 import { buildWebAiSnapshot } from './ax-snapshot.mjs';
 
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('./vendor-editor-contract.mjs').VendorName} VendorName */
+
+/**
+ * @typedef {Object} AuditDrift
+ * @property {string} feature
+ * @property {'error' | 'warn'} severity
+ * @property {string} message
+ */
+
+/**
+ * @typedef {Object} AuditResult
+ * @property {VendorName} vendor
+ * @property {string} snapshotId
+ * @property {number} driftCount
+ * @property {AuditDrift[]} errors
+ * @property {AuditDrift[]} warnings
+ * @property {AuditDrift[]} drifts
+ */
+
+/**
+ * @param {Page} page
+ * @param {VendorName} vendor
+ * @returns {Promise<AuditResult>}
+ */
 export async function auditContractAgainstSnapshot(page, vendor) {
     const contract = editorContractForVendor(vendor);
     const snapshot = await buildWebAiSnapshot(page, { maxDepth: 3 });
     
+    /** @type {AuditDrift[]} */
     const drifts = [];
     for (const [feature, target] of Object.entries(contract.semanticTargets || {})) {
-        const matches = snapshot.refs.filter(ref => 
+        const matches = (/** @type {any} */ (snapshot.refs)).filter(/** @param {any} ref */ (ref) =>
             target.roles?.includes(ref.role) &&
             target.names?.some(p => p.test(ref.name))
         );


### PR DESCRIPTION
VERDICT-B per-file ts-check on web-ai/contract-audit.mjs (30 lines). All deps already DOM-checked: vendor-editor-contract (P30), ax-snapshot.

Changes: // @ts-check, AuditDrift/AuditResult typedefs, JSDoc on single export. snapshot.refs is typed as Record<string, InteractiveRef> by ax-snapshot, but code calls .filter on it (pre-existing mismatch). Preserved via inline any  JSDoc-only.cast 

No runtime change. Control flow byte-identical.

Gates: tsc -p tsconfig.checkjs-dom.json OK, tsc -p tsconfig.checkjs.json OK, tsc --noEmit OK, check:strict-baseline OK.
