### PR TITLE
P34: strict checkjs for web-ai/target-resolver.mjs

### DIFF
--- a/tsconfig.checkjs-dom.json
+++ b/tsconfig.checkjs-dom.json
@@ -18,7 +18,8 @@
     "web-ai/vendor-editor-contract.mjs",
     "web-ai/contract-audit.mjs",
     "web-ai/self-heal.mjs",
-    "web-ai/action-intent.mjs"
+    "web-ai/action-intent.mjs",
+    "web-ai/target-resolver.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/web-ai/target-resolver.mjs
+++ b/web-ai/target-resolver.mjs
@@ -1,6 +1,15 @@
+// @ts-check
 import { createActionIntent, serializeActionIntent } from './action-intent.mjs';
 import { resolveActionTarget } from './self-heal.mjs';
 
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('./action-intent.mjs').ActionIntentInput} ActionIntentInput */
+
+/**
+ * @param {Page} page
+ * @param {ActionIntentInput} [intentInput]
+ * @param {Record<string, any>} [options]
+ */
 export async function resolveTargetForIntent(page, intentInput = {}, options = {}) {
     const actionIntent = createActionIntent(intentInput);
     const resolution = await resolveActionTarget(page, {
@@ -15,6 +24,10 @@ export async function resolveTargetForIntent(page, intentInput = {}, options = {
     return formatResolverResult(actionIntent, resolution);
 }
 
+/**
+ * @param {ActionIntentInput} [actionIntentInput]
+ * @param {{ ok?: boolean, attempts?: Array<{ validation?: { ok?: boolean, confidence?: number }, source?: string }>, target?: { confidence?: number, resolution?: string } | null, errorCode?: string | null, required?: boolean }} [resolution]
+ */
 export function formatResolverResult(actionIntentInput = {}, resolution = {}) {
     const actionIntent = serializeActionIntent(actionIntentInput);
     const selectedAttempt = resolution.attempts?.find(attempt => attempt.validation?.ok) || null;


### PR DESCRIPTION
## P34: web-ai/target-resolver.mjs strict checkjs

VERDICT-B per-file `// @ts-check` + JSDoc. No runtime change.

- 2 functions JSDoc'd, ActionIntentInput typedef via `import()`
- Append to tsconfig.checkjs-dom.json
- All 4 gates 
