### PR TITLE
P36: strict checkjs for scripts/smoke-bins.mjs

### DIFF
--- a/scripts/smoke-bins.mjs
+++ b/scripts/smoke-bins.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 // smoke-bins: prove both bin shims execute and respond to --help.
 // Used in P00, P01, and every later phase to lock the bin contract.
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -61,7 +61,8 @@
     "web-ai/tab-finalizer.mjs",
     "skills/browser/skill-install.mjs",
     "web-ai/tab-recovery.mjs",
-    "skills/browser/tab-lifecycle.mjs"
+    "skills/browser/tab-lifecycle.mjs",
+    "scripts/smoke-bins.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## P36: strict checkjs for scripts/smoke-bins.mjs

VERDICT-B per-file `// @ts-check` migration.

### Scope
- `scripts/smoke-bins.mjs` (58  pure Node leaf script (only `node:child_process`, `node:fs`, `node:path`, `node:url` imports). No internal project deps.lines) 

### Changes
1. Add `// @ts-check` directive at top of file
2. Append `"scripts/smoke-bins.mjs"` to tsconfig.checkjs.json `include`
3. Add `uploads/` and `.browser-agent/` to `.gitignore` (housekeeping)

### Gates (all green at HEAD)
- `npx tsc -p tsconfig.checkjs.json -- cleannoEmit` 
- `npx tsc -p tsconfig.checkjs-dom.json -- cleannoEmit` 
- `node --check scripts/smoke-bins. okmjs` 
- `npm  473 passed, 12 skipped (71 files)test` 

### VERDICT-B compliance
- No runtime change. Only annotation directive added.
- File extension preserved (.mjs).
- No new bindings, no Function.length changes.

Phase 36 of strict-migration. Substrate (P00.P03) merged earlier; this is a content-phase PR.5
