### PR TITLE
P37: strict checkjs for vitest.config.mjs

### DIFF
--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -62,7 +62,8 @@
     "skills/browser/skill-install.mjs",
     "web-ai/tab-recovery.mjs",
     "skills/browser/tab-lifecycle.mjs",
-    "scripts/smoke-bins.mjs"
+    "scripts/smoke-bins.mjs",
+    "vitest.config.mjs"
   ],
   "exclude": [
     "node_modules",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
## P37: strict checkjs for vitest.config.mjs

VERDICT-B per-file `// @ts-check` migration. True leaf (only `vitest/config` import).

### Diff (2 files, 3 insertions, 1 deletion)
- `vitest.config.mjs`: + `// @ts-check` at line 1
- `tsconfig.checkjs.json`: append `"vitest.config.mjs"` to include[]

### Gates (all PASS)
 clean
 clean
 ok
 473 passed, 12 skipped (71 files)

### VERDICT-B compliance
- Annotation-only directive
- No runtime change
- No new bindings, signatures, or expression evaluation changes
- File extension preserved (.mjs)
