### PR TITLE
P39: strict checkjs for benchmarks/agbrowse/run-task.mjs

### DIFF
--- a/benchmarks/agbrowse/run-task.mjs
+++ b/benchmarks/agbrowse/run-task.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 import fs from 'node:fs/promises';
 import process from 'node:process';
 import {
@@ -8,6 +9,10 @@ import {
     writeTrajectoryBundle,
 } from './trajectory.mjs';
 
+/**
+ * @param {string[]} [argv]
+ * @returns {Promise<number>}
+ */
 async function main(argv = process.argv.slice(2)) {
     const opts = parseArgs(argv);
     if (opts.help) {
@@ -27,14 +32,19 @@ async function main(argv = process.argv.slice(2)) {
     });
     const result = await writeTrajectoryBundle(trajectory, outputDir);
     if (opts.json) {
-        process.stdout.write(`${JSON.stringify({ ok: true, ...result }, null, 2)}\n`);
+        process.stdout.write(`${JSON.stringify({ ok: true, ...(/** @type {any} */ (result)) }, null, 2)}\n`);
     } else {
         process.stdout.write(`wrote trajectory: ${result.path}\n`);
     }
     return 0;
 }
 
+/**
+ * @param {string[]} argv
+ * @returns {{ help?: boolean, json?: boolean, input?: string, outputDir?: string }}
+ */
 function parseArgs(argv) {
+    /** @type {{ help?: boolean, json?: boolean, input?: string, outputDir?: string }} */
     const opts = {};
     for (let i = 0; i < argv.length; i += 1) {
         const arg = argv[i];

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -64,7 +64,8 @@
     "skills/browser/tab-lifecycle.mjs",
     "scripts/smoke-bins.mjs",
     "vitest.config.mjs",
-    "benchmarks/agbrowse/trajectory.mjs"
+    "benchmarks/agbrowse/trajectory.mjs",
+    "benchmarks/agbrowse/run-task.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## P39: strict checkjs for benchmarks/agbrowse/run-task.mjs

VERDICT-B per-file `// @ts-check` migration. Imports only `./trajectory.mjs` (already strict-checked at P38) + node built-ins.

### Diff
- `benchmarks/agbrowse/run-task.mjs`: + `// @ts-check`, JSDoc `@param`/`@returns` on `main()` and `parseArgs()`, JSDoc `/** @} */` annotation on `const opts = {}`, inline `/** @type {any} */` cast on spread to suppress duplicate-property TS warning.type {
- `tsconfig.checkjs.json`: append entry.

### Gates (all PASS)
 0
 0
 ok
 473 passed, 12 skipped

### VERDICT-B compliance
-  JSDoc-only annotations
-  `const opts = {}` is the SAME existing binding; the `/** @type */` above is annotation, not a new declaration
-  `{ ok: true, ...(/** @type {any} */ ( runtime-identical to the original; cast is JSDoc comment + `(result)` parensresult)) }` 
-  Function signatures and arities unchanged
-  tsconfig append-only
