### PR TITLE
P40: strict checkjs for scripts/render-trace-report.mjs

### DIFF
--- a/scripts/render-trace-report.mjs
+++ b/scripts/render-trace-report.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 import { parseArgs } from 'node:util';
 import { renderTraceReport } from '../web-ai/trace/report.mjs';
 

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -65,7 +65,8 @@
     "scripts/smoke-bins.mjs",
     "vitest.config.mjs",
     "benchmarks/agbrowse/trajectory.mjs",
-    "benchmarks/agbrowse/run-task.mjs"
+    "benchmarks/agbrowse/run-task.mjs",
+    "scripts/render-trace-report.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## P40: strict checkjs for scripts/render-trace-report.mjs

VERDICT-B per-file `// @ts-check` migration. 17-line CLI wrapper that imports `renderTraceReport` from `web-ai/trace/report.mjs` (already strict-checked).

### Diff (2 files, 3 insertions, 1 deletion)
- `scripts/render-trace-report.mjs`: + `// @ts-check` at line 2 (after shebang)
- `tsconfig.checkjs.json`: append entry

### Gates (all PASS)
 0
 0
 ok
 473 passed, 12 skipped, 71 files

### VERDICT-B compliance
-  Annotation-only directive
-  No JSDoc additions needed (file passes strict on first try due to upstream typing)
-  No runtime change
