### PR TITLE
P46: strict checkjs for bin/agbrowse-vision-click.mjs

### DIFF
--- a/bin/agbrowse-vision-click.mjs
+++ b/bin/agbrowse-vision-click.mjs
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
+// @ts-check
 import '../skills/vision-click/vision-click.mjs';

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -71,7 +71,8 @@
     "scripts/run-web-ai-eval.mjs",
     "scripts/check-strict-baseline.mjs",
     "scripts/check-module-graph.mjs",
-    "skills/vision-click/vision-click.mjs"
+    "skills/vision-click/vision-click.mjs",
+    "bin/agbrowse-vision-click.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## P46: strict checkjs for bin/agbrowse-vision-click.mjs

2-line CLI shim. Just re-exports skills/vision-click/vision-click.mjs (P45). Adds // @ts-check, appends to tsconfig.checkjs.json.

### Gates
 0
 0
 ok
 473 passed, 12 skipped

VERDICT-B: directive only.
