### PR TITLE
fix(strict): revert P46 // @ts-check from agbrowse-vision-click shim

### DIFF
--- a/bin/agbrowse-vision-click.mjs
+++ b/bin/agbrowse-vision-click.mjs
@@ -1,3 +1,2 @@
 #!/usr/bin/env node
-// @ts-check
 import '../skills/vision-click/vision-click.mjs';

--- a/tsconfig.checkjs.json
+++ b/tsconfig.checkjs.json
@@ -71,8 +71,7 @@
     "scripts/run-web-ai-eval.mjs",
     "scripts/check-strict-baseline.mjs",
     "scripts/check-module-graph.mjs",
-    "skills/vision-click/vision-click.mjs",
-    "bin/agbrowse-vision-click.mjs"
+    "skills/vision-click/vision-click.mjs"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
P46 broke bin-shim-contract test (shim is 2-line re-export, // @ts-check pragma fails the single-non-empty-line assertion). Revert + remove tsconfig entry. Tests now 473 passed.