### PR TITLE
Add ChatGPT composer tool selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,9 +899,10 @@ agbrowse web-ai query \
 ```
 
 Deep Research saves a report artifact when available, records
-`researchMode: "deep"` in the session, and skips auto archive. Account blocks
-or missing provider UI surfaces are reported explicitly; do not treat this as a
-ready cross-provider capability.
+`researchMode: "deep"` in the session, skips auto archive, and auto-confirms
+ChatGPT's post-submit Deep Research plan card when its time-limited `Start`
+button appears. Account blocks or missing provider UI surfaces are reported
+explicitly; do not treat this as a ready cross-provider capability.
 
 ## ChatGPT Project Sources
 

--- a/README.md
+++ b/README.md
@@ -900,9 +900,10 @@ agbrowse web-ai query \
 
 Deep Research saves a report artifact when available, records
 `researchMode: "deep"` in the session, skips auto archive, and auto-confirms
-ChatGPT's post-submit Deep Research plan card when its time-limited `Start`
-button appears. Account blocks or missing provider UI surfaces are reported
-explicitly; do not treat this as a ready cross-provider capability.
+ChatGPT's post-submit Deep Research plan card when its iframe-rendered,
+time-limited `Start` button appears (live observed as an approximately
+60-second countdown). Account blocks or missing provider UI surfaces are
+reported explicitly; do not treat this as a ready cross-provider capability.
 
 ## ChatGPT Project Sources
 

--- a/devlog/00_index.md
+++ b/devlog/00_index.md
@@ -27,6 +27,7 @@ must be treated as historical  do not edit them after release.evidence
 | web-ai code mode GPT dev-agent context | `_plan/260611_code_mode_gpt_agent_context/` | Active: auto-upload saved GPT dev-agent context zip, require `PLAN.md`/`00_plan.md`, and mirror independent runtime into cli-jaw. |
 | web-ai skill + cli-jaw mirror closeout | `_plan/260611_webai_skill_cli_jaw_mirror/` | Active: update agent-facing skill docs and mirror the simplified ChatGPT Intelligence picker into cli-jaw. |
 | Background runtime hook research | `_plan/260611_background_runtime_hook/` | Research complete; findings reflected in `skills/web-ai/SKILL.md` (Long-Running section). Hook design relocated to cli-jaw `devlog/_plan/260611_bgtask_background_runtime/` for implementation planning. |
+| ChatGPT composer tool selection live probe | `_plan/260615_chatgpt_composer_tools_live_probe.md` | Active: PR #78 live DOM/UX evidence for explicit-only tool/plugin/model gating. |
 
 ## `_fin/mvp/` topics
 

--- a/devlog/_plan/260615_chatgpt_composer_tools_live_probe.md
+++ b/devlog/_plan/260615_chatgpt_composer_tools_live_probe.md
@@ -173,6 +173,31 @@ Observed implication:
 - App/plugin connector choices can leave the composer and enter authorization/account-linking UX.
 - These choices must remain explicit-only and should not be part of `--auto-tools` unless the caller requested that connector and accepts auth-flow behavior.
 
+## Deep research post-submit plan card
+
+A later live submit smoke on 2026-06-15 confirmed an additional Deep Research UI after the prompt is submitted.
+
+Prompt used:
+
+`AGBROWSE_DEEP_RESEARCH_POST_SUBMIT_UI_TEST. Briefly research what RFC 2119 keyword MUST means; keep the final answer short.`
+
+Observed within the first post-submit window:
+
+- ChatGPT created a conversation URL and rendered the user message.
+- A Deep Research plan card appeared above the composer.
+- Card title: `Define RFC 2119 MUST`
+- Plan rows:
+  - `Open RFC 2119 official document from IETF website.`
+  - `Extract the exact definition and examples of MUST from RFC 2119.`
+  - `Cross-check definition with RFC 8174 updates for keyword interpretation.`
+  - `Summarize the meaning concisely for non-expert readers.`
+- Buttons:
+  - `Edit`
+  - `Cancel`
+  - `Start` with a countdown indicator (`5` observed)
+- This card is time-sensitive; the `Start` choice appears in the first ~15 seconds. The pre-existing code only looked for `Start research` / `Confirm`, so it could miss the current `Start` button.
+- AX/browser observe and ordinary document query did not reliably expose this card, but the screenshot confirmed the visible UI. The repository runtime uses Playwright selectors, so the practical selector fix is to include `button:has-text("Start")` and Korean `button:has-text("시작")`.
+
 ## Current code judgment
 
 Keep these constraints for PR #78 follow-up work:
@@ -191,6 +216,7 @@ Keep these constraints for PR #78 follow-up work:
 - Kept explicit `--plugin <name>` support unchanged.
 - Updated CLI help and bundled `skills/web-ai/SKILL.md` so `--auto-tools` is described as non-auth tool inference only.
 - Added/updated unit expectations that GitHub/Supabase prompts do not auto-select plugins.
+- Added post-submit Deep Research auto-confirm labels for `Start` / `시작`, widened the confirm window to 15 seconds, and reduced polling to 250ms.
 
 ## Verification already run for the branch before this live probe
 

--- a/devlog/_plan/260615_chatgpt_composer_tools_live_probe.md
+++ b/devlog/_plan/260615_chatgpt_composer_tools_live_probe.md
@@ -181,22 +181,26 @@ Prompt used:
 
 `AGBROWSE_DEEP_RESEARCH_POST_SUBMIT_UI_TEST. Briefly research what RFC 2119 keyword MUST means; keep the final answer short.`
 
-Observed within the first post-submit window:
+Observed across repeated post-submit windows:
 
 - ChatGPT created a conversation URL and rendered the user message.
 - A Deep Research plan card appeared above the composer.
-- Card title: `Define RFC 2119 MUST`
-- Plan rows:
+- The plan card content is rendered inside a Deep Research app iframe (`about:blank` child frame observed under the `connector_openai_deep_research.web-sandbox.oaiusercontent.com` app frame), not reliably in the main ChatGPT DOM.
+- Example card title: `Define RFC 2119 MUST`
+- Example plan rows:
   - `Open RFC 2119 official document from IETF website.`
   - `Extract the exact definition and examples of MUST from RFC 2119.`
   - `Cross-check definition with RFC 8174 updates for keyword interpretation.`
   - `Summarize the meaning concisely for non-expert readers.`
+- A more complex prompt produced card title `RFC keyword usage comparison` and five rows, with `Start` countdown values `46`, `41`, and `35` observed in successive screenshots.
+- Another fresh branch probe produced `Lockfile security policy comparison` with `Start 59`, so the live countdown window is approximately 60 seconds, not 15 seconds.
 - Buttons:
   - `Edit`
   - `Cancel`
-  - `Start` with a countdown indicator (`5` observed)
-- This card is time-sensitive; the `Start` choice appears in the first ~15 seconds. The pre-existing code only looked for `Start research` / `Confirm`, so it could miss the current `Start` button.
-- AX/browser observe and ordinary document query did not reliably expose this card, but the screenshot confirmed the visible UI. The repository runtime uses Playwright selectors, so the practical selector fix is to include `button:has-text("Start")` and Korean `button:has-text("시작")`.
+  - `Start` with countdown text (`Plan starts in NN seconds.` in iframe text)
+- Letting the countdown expire automatically transitions the card to `Researching...`; manual `Start` is an accelerator, not the only path forward.
+- Clicking a plan row's left circular glyph did not toggle/select that row. The only observed text/body change was the countdown decrement, and the row HTML stayed effectively unchanged. Treat those left circles as status/progress icons, not user-selectable checklist toggles.
+- AX/browser observe and ordinary main document query did not reliably expose this card; iframe scanning did. The repository runtime uses Playwright selectors, so the practical selector fix is to scan `page.frames()` and include `button:has-text("Start")` / Korean `button:has-text("시작")`.
 
 ## Current code judgment
 
@@ -210,13 +214,13 @@ Keep these constraints for PR #78 follow-up work:
 6. Deep Research `Specific sites` / `Manage sites` and `Apps` connector flows are explicit future surfaces, not default behavior.
 7. Plugin/app connector selections are potentially auth-sensitive and must stay gated behind explicit flags.
 
-## Follow-up patch applied from this probe
+## Follow-up patches applied from this probe
 
 - Removed `--auto-tools` plugin inference for GitHub/Supabase-style prompts.
 - Kept explicit `--plugin <name>` support unchanged.
 - Updated CLI help and bundled `skills/web-ai/SKILL.md` so `--auto-tools` is described as non-auth tool inference only.
 - Added/updated unit expectations that GitHub/Supabase prompts do not auto-select plugins.
-- Added post-submit Deep Research auto-confirm labels for `Start` / `시작`, widened the confirm window to 15 seconds, and reduced polling to 250ms.
+- Added post-submit Deep Research auto-confirm labels for `Start` / `시작`, then corrected the live behavior to scan Deep Research app iframes and wait up to 70 seconds for the observed ~60 second Start card.
 
 ## Verification already run for the branch before this live probe
 

--- a/devlog/_plan/260615_chatgpt_composer_tools_live_probe.md
+++ b/devlog/_plan/260615_chatgpt_composer_tools_live_probe.md
@@ -1,0 +1,201 @@
+# ChatGPT composer tools live probe — PR #78
+
+Date: 2026-06-15
+Branch: `pr-78-chatgpt-tools`
+Relevant commits at probe time:
+
+- `51268ef Preserve ChatGPT web search tool pill`
+- `fa2e806 Avoid implicit ChatGPT selector traversal`
+- `74d6da7 Guard default ChatGPT composer selection`
+- PR base commit: `525a0a2 [verified] Add ChatGPT composer tool selection`
+
+## Product boundary being verified
+
+Default ChatGPT sends must not traverse model/tool/plugin menus. Composer model/tool/menu selection is allowed only when the caller passes explicit flags such as `--model`, `--effort`, `--tool`, `--plugin`, `--web-search`, or `--auto-tools`.
+
+This matters because several ChatGPT composer menus have side effects beyond a harmless selection:
+
+- `Web search` becomes a removable composer pill and can be undone by extra Escape presses.
+- Deep research opens a different composer UX with `Apps` and `Sites` submenus.
+- Some app/plugin choices open external connector authorization flows.
+
+## Live environment
+
+- Attached to the existing ChatGPT browser session through agbrowse CDP (`http://127.0.0.1:9222`).
+- No prompt was intentionally submitted for the Deep research/menu probe.
+- Element IDs from `observe` are transient browser-tool IDs; role/name/state strings below are the stable evidence.
+
+## Baseline model/effort UX
+
+Starting state on a new ChatGPT composer showed the simplified Intelligence picker.
+
+Observed model menu entries after opening the composer model button:
+
+- `Instant`
+- `Medium`
+- `High`
+- `Extra High`
+- `Pro Extended`
+- `GPT-5.5` submenu
+
+Observed behavior:
+
+- Selecting `Instant` changed the composer model pill to `Instant`.
+- This maps to the user's requested "low"/light reasoning smoke path for the simplified picker.
+- Model/effort selection is verified as an explicit path only; default sends must not touch this menu.
+
+## Top-level composer plus menu
+
+Opening the plus button (`aria`: `Add files and more`) on a normal composer produced the following accessible menu items:
+
+- `Add photos & files Command U`
+- `Recent files`
+- `Create image` (`role=menuitemradio`, `checked=false`)
+- `Deep research` (`role=menuitemradio`, `checked=false`)
+- `Web search` (`role=menuitemradio`, `checked=false`)
+- `More`
+- `Projects`
+
+Observed implications:
+
+- `Create image`, `Deep research`, and `Web search` are radio-style tool selections, not ordinary inert menu items.
+- Automation must not cycle through these in the default send path.
+- Explicit `--web-search` must select only `Web search` and leave a visible `Search` pill checked in the menu.
+
+## Web search toggle/pill behavior
+
+Live web-search smoke before this probe established:
+
+- Explicit `--web-search` successfully selected the top-level Web Search tool.
+- The plus menu then showed `Web search` checked.
+- The composer showed an active `Search` pill / accessible label `Search, click to remove`.
+- Pressing Escape once closes the open menu while preserving the pill.
+- Pressing Escape twice removes the active tool pill.
+
+Code consequence already applied in `51268ef`:
+
+- `closeComposerMenus()` now sends one Escape instead of two, because the second Escape can undo `Web search`.
+
+## Deep research top-level selection
+
+Clicking the top-level `Deep research` menu item changed the composer UX.
+
+Observed accessible state after selection:
+
+- Active pill: button name `Deep research, click to remove`
+- Placeholder/visual affordance: `Get a detailed report`
+- Additional composer buttons:
+  - `Apps` (`expanded=false`)
+  - `Sites, search the web, no sites saved` (`expanded=false`)
+  - Model button `Instant` (`expanded=false`)
+- Suggested tabs:
+  - `Suggested` (`selected=true`)
+  - `Reports` (`selected=false`)
+- Suggested report prompt buttons appear below the composer.
+
+Observed implication:
+
+- Selecting Deep research is not the end of the UX; it exposes a second-level source selection area.
+- The safe default after Deep research is already `Sites, search the web, no sites saved`.
+- Automation should not force site/app submenus unless a future explicit option asks for that specific behavior.
+
+## Deep research Sites menu
+
+Opening `Sites` while Deep research is active produced a menu named `Sites, search the web, no sites saved`.
+
+Observed menu items:
+
+- `Search the web`
+- `Specific sites (0)`
+- `Manage sites`
+
+Observed behavior for each direct click:
+
+### `Search the web`
+
+- It is the default/checked visual state when the menu opens.
+- It represents the safe generic web source for Deep research.
+- No separate URL/account flow is needed.
+
+### `Specific sites (0)`
+
+- Direct click opens a modal titled/visible as `Search specific sites`.
+- DOM includes:
+  - input name `Add a website`
+  - placeholder `Add site URLs, separated by commas`
+  - `Add` button disabled when input is empty
+  - close button `Close`
+- While the modal is open, the composer Sites button can show `Sites, specific sites, no sites saved` / `Sites (0)`.
+- Closing without adding URLs returns the composer to `Sites, search the web, no sites saved`.
+
+### `Manage sites`
+
+- Direct click opens the same `Search specific sites` modal shape.
+- DOM includes the same `Add a website` input and disabled `Add` button.
+- This is not a safe implicit default path; it is a user-data/site-list management flow.
+
+Clarification:
+
+- A transient disappearance of the Deep research pill during this live session is excluded from automation evidence. The user clarified that they manually clicked the UI at that moment.
+
+## Deep research Apps menu
+
+Opening `Apps` while Deep research is active produced a menu named `Apps`.
+
+Observed menu items:
+
+- `Box (Legacy) Box Connect`
+- `Dropbox (Legacy) Dropbox Connect`
+- `GitHub GitHub Connect`
+- `Gmail Gmail Connect`
+- `Google Calendar Google Calendar Connect`
+- `Google Drive Google Drive Connect`
+- `Connect more`
+
+Direct click smoke:
+
+- Clicking `GitHub GitHub Connect` navigated/opened the settings connector flow:
+  - URL hash: `#settings/Connectors?add-connector-link=true&product-sku=PROMPT_TEXT_AREA&connector=...&referrer=sources_dropdown`
+  - dialog role: `dialog`
+  - buttons/links included:
+    - `Close`
+    - `Learn more`
+    - `Learn more on how to stay safe`
+    - `Continue to GitHub`
+- The connector flow was closed without clicking `Continue to GitHub`.
+- After closing, ChatGPT returned to the Deep research composer state with:
+  - `Deep research, click to remove`
+  - `Sites, search the web, no sites saved`
+  - `Instant`
+
+Observed implication:
+
+- App/plugin connector choices can leave the composer and enter authorization/account-linking UX.
+- These choices must remain explicit-only and should not be part of `--auto-tools` unless the caller requested that connector and accepts auth-flow behavior.
+
+## Current code judgment
+
+Keep these constraints for PR #78 follow-up work:
+
+1. No default model/effort selection.
+2. No default composer tool traversal.
+3. One Escape only after tool selection; a second Escape can remove selected tool pills.
+4. `--web-search` should only select the Web Search pill and preserve it.
+5. `--tool deep-research` should select the Deep research pill and preserve the default Deep Research source state (`Sites, search the web, no sites saved`).
+6. Deep Research `Specific sites` / `Manage sites` and `Apps` connector flows are explicit future surfaces, not default behavior.
+7. Plugin/app connector selections are potentially auth-sensitive and must stay gated behind explicit flags.
+
+## Follow-up patch applied from this probe
+
+- Removed `--auto-tools` plugin inference for GitHub/Supabase-style prompts.
+- Kept explicit `--plugin <name>` support unchanged.
+- Updated CLI help and bundled `skills/web-ai/SKILL.md` so `--auto-tools` is described as non-auth tool inference only.
+- Added/updated unit expectations that GitHub/Supabase prompts do not auto-select plugins.
+
+## Verification already run for the branch before this live probe
+
+- `node --check web-ai/chatgpt-tools.mjs`
+- `npm run -s typecheck:checkjs`
+- `node_modules/.bin/vitest run test/unit/web-ai-chatgpt-tools.test.mjs`
+- Live ChatGPT `--web-search` smoke: selected Web Search and preserved pill after the one-Escape fix.
+- Live ChatGPT Deep research click smoke: selected Deep research, surfaced Apps/Sites UX, and preserved default `Sites, search the web` source state.

--- a/skills/web-ai/SKILL.md
+++ b/skills/web-ai/SKILL.md
@@ -479,6 +479,8 @@ Supported `--plugin` aliases under `더 보기`:
 - `github`, `gmail`, `google-drive`, `google-calendar`, `google-contacts`
 - `supabase`, `vercel`, `figma`, `canva`, `context7`, `openai-platform`
 
+Composer menus are not opened on the default send/query path. They are touched only when `--tool`, `--plugin`, `--web-search`, `--auto-tools`, `--output-image`, or `--research deep` requests a composer selection.
+
 Use `--auto-tools` when you want agbrowse to infer obvious tools from the prompt:
 
 - current/latest/news/price/official/source-sensitive prompt → web search

--- a/skills/web-ai/SKILL.md
+++ b/skills/web-ai/SKILL.md
@@ -488,7 +488,7 @@ Use `--auto-tools` when you want agbrowse to infer obvious tools from the prompt
 - deep research / 심층 리서치 prompt → deep research
 - `--plugin <name>` remains explicit-only because connector/plugin choices may open account-linking or authorization UI.
 
-Live-verified 2026-06-15 on Korean/English ChatGPT UI: `파일 추가 및 기타` / `Add files and more`, `이미지 만들기` / `Create image`, `심층 리서치` / `Deep research`, `웹 검색` / `Web search`, `더 보기` / `More`, the Deep research `Apps` and `Sites` submenus, and connector entries including `GitHub`, `Gmail`, `Google 드라이브`, and `Google Calendar`. Connector/plugin entries are explicit-only.
+Live-verified 2026-06-15 on Korean/English ChatGPT UI: `파일 추가 및 기타` / `Add files and more`, `이미지 만들기` / `Create image`, `심층 리서치` / `Deep research`, `웹 검색` / `Web search`, `더 보기` / `More`, the Deep research `Apps` and `Sites` submenus, the post-submit Deep Research plan card with `Start`, and connector entries including `GitHub`, `Gmail`, `Google 드라이브`, and `Google Calendar`. Connector/plugin entries are explicit-only.
 
 ## Generated Images
 
@@ -558,8 +558,9 @@ agbrowse web-ai query \
   --prompt "Research the current official status and cite sources."
 ```
 
-Deep Research saves a report artifact when available and skips auto archive.
-Do not claim cross-provider Deep Research support.
+Deep Research saves a report artifact when available, skips auto archive, and
+auto-confirms ChatGPT's post-submit plan card when its time-limited `Start` /
+`시작` button appears. Do not claim cross-provider Deep Research support.
 
 ## ChatGPT Project Sources
 

--- a/skills/web-ai/SKILL.md
+++ b/skills/web-ai/SKILL.md
@@ -488,7 +488,7 @@ Use `--auto-tools` when you want agbrowse to infer obvious tools from the prompt
 - deep research / 심층 리서치 prompt → deep research
 - `--plugin <name>` remains explicit-only because connector/plugin choices may open account-linking or authorization UI.
 
-Live-verified 2026-06-15 on Korean/English ChatGPT UI: `파일 추가 및 기타` / `Add files and more`, `이미지 만들기` / `Create image`, `심층 리서치` / `Deep research`, `웹 검색` / `Web search`, `더 보기` / `More`, the Deep research `Apps` and `Sites` submenus, the post-submit Deep Research plan card with `Start`, and connector entries including `GitHub`, `Gmail`, `Google 드라이브`, and `Google Calendar`. Connector/plugin entries are explicit-only.
+Live-verified 2026-06-15 on Korean/English ChatGPT UI: `파일 추가 및 기타` / `Add files and more`, `이미지 만들기` / `Create image`, `심층 리서치` / `Deep research`, `웹 검색` / `Web search`, `더 보기` / `More`, the Deep research `Apps` and `Sites` submenus, the iframe-rendered post-submit Deep Research plan card with a ~60-second `Start` countdown, and connector entries including `GitHub`, `Gmail`, `Google 드라이브`, and `Google Calendar`. Connector/plugin entries are explicit-only.
 
 ## Generated Images
 
@@ -559,8 +559,9 @@ agbrowse web-ai query \
 ```
 
 Deep Research saves a report artifact when available, skips auto archive, and
-auto-confirms ChatGPT's post-submit plan card when its time-limited `Start` /
-`시작` button appears. Do not claim cross-provider Deep Research support.
+auto-confirms ChatGPT's iframe-rendered post-submit plan card when its
+time-limited `Start` / `시작` button appears. Do not claim cross-provider Deep
+Research support.
 
 ## ChatGPT Project Sources
 

--- a/skills/web-ai/SKILL.md
+++ b/skills/web-ai/SKILL.md
@@ -486,10 +486,9 @@ Use `--auto-tools` when you want agbrowse to infer obvious tools from the prompt
 - current/latest/news/price/official/source-sensitive prompt → web search
 - image/illustration/poster generation prompt → image
 - deep research / 심층 리서치 prompt → deep research
-- GitHub/repo/PR/branch prompt → GitHub plugin
-- Supabase/RLS/migration prompt → Supabase plugin
+- `--plugin <name>` remains explicit-only because connector/plugin choices may open account-linking or authorization UI.
 
-Live-verified 2026-06-15 on Korean ChatGPT UI: `파일 추가 및 기타`, `이미지 만들기`, `심층 리서치`, `웹 검색`, `더 보기`, and plugins including `GitHub`, `Supabase`, `Vercel`, `Gmail`, `Google 드라이브`, `Google Calendar`.
+Live-verified 2026-06-15 on Korean/English ChatGPT UI: `파일 추가 및 기타` / `Add files and more`, `이미지 만들기` / `Create image`, `심층 리서치` / `Deep research`, `웹 검색` / `Web search`, `더 보기` / `More`, the Deep research `Apps` and `Sites` submenus, and connector entries including `GitHub`, `Gmail`, `Google 드라이브`, and `Google Calendar`. Connector/plugin entries are explicit-only.
 
 ## Generated Images
 

--- a/skills/web-ai/SKILL.md
+++ b/skills/web-ai/SKILL.md
@@ -453,6 +453,42 @@ Do not claim cli-jaw parity for this command unless the equivalent cli-jaw
 command surface, retrieval runtime, tests, and installed skill docs are
 implemented there.
 
+## ChatGPT Composer Tools and Plugins
+
+ChatGPT's composer `+` menu can be selected before sending:
+
+```bash
+agbrowse web-ai query \
+  --vendor chatgpt \
+  --inline-only \
+  --tool web-search \
+  --plugin github \
+  --prompt "Review the current GitHub repo status."
+```
+
+Supported tool aliases:
+
+- `--tool image` → `이미지 만들기` / Create image
+- `--tool deep-research` or `--research deep` → `심층 리서치` / Deep Research
+- `--tool web-search` or `--web-search` → `웹 검색` / Web search
+- `--tool agent-mode` → `에이전트 모드`
+- `--tool tasks` → `할 일 만들기`
+
+Supported `--plugin` aliases under `더 보기`:
+
+- `github`, `gmail`, `google-drive`, `google-calendar`, `google-contacts`
+- `supabase`, `vercel`, `figma`, `canva`, `context7`, `openai-platform`
+
+Use `--auto-tools` when you want agbrowse to infer obvious tools from the prompt:
+
+- current/latest/news/price/official/source-sensitive prompt → web search
+- image/illustration/poster generation prompt → image
+- deep research / 심층 리서치 prompt → deep research
+- GitHub/repo/PR/branch prompt → GitHub plugin
+- Supabase/RLS/migration prompt → Supabase plugin
+
+Live-verified 2026-06-15 on Korean ChatGPT UI: `파일 추가 및 기타`, `이미지 만들기`, `심층 리서치`, `웹 검색`, `더 보기`, and plugins including `GitHub`, `Supabase`, `Vercel`, `Gmail`, `Google 드라이브`, `Google Calendar`.
+
 ## Generated Images
 
 Use ChatGPT only:
@@ -461,6 +497,7 @@ Use ChatGPT only:
 agbrowse web-ai query \
   --vendor chatgpt \
   --inline-only \
+  --tool image \
   --output-image ./out.png \
   --prompt "Create an image of a small robot holding a banana."
 ```
@@ -604,6 +641,16 @@ ChatGPT:
 - `thinking --effort heavy` selects `Extra High`.
 - `pro --effort standard` selects `Pro Extended` when the simplified UI only exposes Pro Extended; if ChatGPT exposes a `Pro Standard` hover submenu, treat it as an optional refinement rather than a required selector.
 - `pro --effort extended` selects `Pro Extended`.
+
+2026-06-15 Korean ChatGPT Intelligence UI note:
+
+- The composer model pill may show `중간` and open a `지능` menu.
+- `instant` / `thinking --effort light` select `즉시`.
+- `thinking --effort standard` selects `중간`.
+- `thinking --effort extended` selects `높음`.
+- `thinking --effort heavy` selects `매우 높음`.
+- `pro --effort extended` selects `Pro 확장`.
+- Pro effort trigger observed as `data-testid="composer-intelligence-pro-thinking-effort-trigger"`.
 
 Gemini:
 

--- a/test/integration/web-ai-cli-contract.test.mjs
+++ b/test/integration/web-ai-cli-contract.test.mjs
@@ -12,7 +12,7 @@ describe('web-ai CLI contract', () => {
         expect(result.stdout).toContain('Provider:');
         expect(result.stdout).toContain('--context-from-files');
         expect(result.stdout).toContain('--effort <alias>');
-        expect(result.stdout).toContain('default for chatgpt: pro');
+        expect(result.stdout).toContain('ChatGPT: instant, thinking, pro');
         expect(result.stdout).toContain('Tab lease policy:');
         expect(result.stdout).toContain('leaseClosedTabs');
         expect(result.stdout).toContain('mcp-server');
@@ -149,14 +149,14 @@ describe('web-ai CLI contract', () => {
         expect(result.stderr).not.toContain('--inline-only');
     });
 
-    it('defaults --model to pro for chatgpt when omitted', async () => {
+    it('does not default --model for chatgpt when omitted', async () => {
         const result = await execBrowser(['web-ai', 'render', '--vendor', 'chatgpt', '--prompt', 'hello']);
         expect(result.code).toBe(0);
-        // No model error and renders successfully (model selection happens at browser-mutation time, not in render).
         expect(result.stderr).not.toContain('unsupported');
-        const effortDefault = await execBrowser(['web-ai', 'render', '--vendor', 'chatgpt', '--prompt', 'hello', '--effort', 'extended']);
-        expect(effortDefault.code).toBe(0);
-        expect(effortDefault.stderr).not.toContain('requires --model');
+
+        const effortWithoutModel = await execBrowser(['web-ai', 'render', '--vendor', 'chatgpt', '--prompt', 'hello', '--effort', 'extended']);
+        expect(effortWithoutModel.code).not.toBe(0);
+        expect(effortWithoutModel.stderr).toContain('reasoning effort requires --model');
     });
 
     it('rejects unsupported ChatGPT model choices', async () => {
@@ -175,9 +175,8 @@ describe('web-ai CLI contract', () => {
         expect(thinking.stderr).not.toContain('unsupported ChatGPT reasoning effort');
 
         const effortOnly = await execBrowser(['web-ai', 'render', '--vendor', 'chatgpt', '--prompt', 'hello', '--effort', 'extended']);
-        // ChatGPT now defaults --model to 'pro' when omitted, so --effort alone is accepted.
-        expect(effortOnly.code).toBe(0);
-        expect(effortOnly.stderr).not.toContain('reasoning effort requires --model');
+        expect(effortOnly.code).not.toBe(0);
+        expect(effortOnly.stderr).toContain('reasoning effort requires --model');
 
         const proHeavy = await execBrowser(['web-ai', 'render', '--vendor', 'chatgpt', '--prompt', 'hello', '--model', 'pro', '--effort', 'heavy']);
         expect(proHeavy.code).not.toBe(0);

--- a/test/unit/web-ai-chatgpt-deep-research.test.mjs
+++ b/test/unit/web-ai-chatgpt-deep-research.test.mjs
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { autoConfirmPlan } from '../../web-ai/chatgpt-deep-research.mjs';
+
+const chatgptDeepResearchSrc = readFileSync(join(process.cwd(), 'web-ai', 'chatgpt-deep-research.mjs'), 'utf8');
+
+describe('web-ai ChatGPT Deep Research flow', () => {
+    it('auto-confirms the post-submit Deep Research Start plan card', async () => {
+        const clicked = [];
+        const page = {
+            locator(selector) {
+                return {
+                    first() {
+                        return this;
+                    },
+                    async isVisible() {
+                        return selector === 'button:has-text("Start")';
+                    },
+                    async click() {
+                        clicked.push(selector);
+                    },
+                };
+            },
+            async waitForTimeout() {
+                throw new Error('should not wait once Start is visible');
+            },
+        };
+
+        await expect(autoConfirmPlan(page, 15_000)).resolves.toBe(true);
+        expect(clicked).toEqual(['button:has-text("Start")']);
+    });
+
+    it('uses the live-observed 15 second post-submit confirmation window', () => {
+        expect(chatgptDeepResearchSrc).toContain('button:has-text("Start research")');
+        expect(chatgptDeepResearchSrc).toContain('button:has-text("Start")');
+        expect(chatgptDeepResearchSrc).toContain('button:has-text("시작")');
+        expect(chatgptDeepResearchSrc).toContain('timeoutMs = 15_000');
+        expect(chatgptDeepResearchSrc).toContain('await page.waitForTimeout(250)');
+    });
+});

--- a/test/unit/web-ai-chatgpt-deep-research.test.mjs
+++ b/test/unit/web-ai-chatgpt-deep-research.test.mjs
@@ -7,7 +7,7 @@ import { autoConfirmPlan } from '../../web-ai/chatgpt-deep-research.mjs';
 const chatgptDeepResearchSrc = readFileSync(join(process.cwd(), 'web-ai', 'chatgpt-deep-research.mjs'), 'utf8');
 
 describe('web-ai ChatGPT Deep Research flow', () => {
-    it('auto-confirms the post-submit Deep Research Start plan card', async () => {
+    it('auto-confirms the post-submit Deep Research Start plan card on the page', async () => {
         const clicked = [];
         const page = {
             locator(selector) {
@@ -23,20 +23,70 @@ describe('web-ai ChatGPT Deep Research flow', () => {
                     },
                 };
             },
+            frames() {
+                return [];
+            },
             async waitForTimeout() {
                 throw new Error('should not wait once Start is visible');
             },
         };
 
-        await expect(autoConfirmPlan(page, 15_000)).resolves.toBe(true);
+        await expect(autoConfirmPlan(page, 70_000)).resolves.toBe(true);
         expect(clicked).toEqual(['button:has-text("Start")']);
     });
 
-    it('uses the live-observed 15 second post-submit confirmation window', () => {
+    it('auto-confirms the Deep Research Start card inside the app iframe', async () => {
+        const clicked = [];
+        const invisibleContext = {
+            locator() {
+                return {
+                    first() {
+                        return this;
+                    },
+                    async isVisible() {
+                        return false;
+                    },
+                    async click() {
+                        throw new Error('should not click the page context');
+                    },
+                };
+            },
+        };
+        const frameContext = {
+            locator(selector) {
+                return {
+                    first() {
+                        return this;
+                    },
+                    async isVisible() {
+                        return selector === 'button:has-text("Start")';
+                    },
+                    async click() {
+                        clicked.push(selector);
+                    },
+                };
+            },
+        };
+        const page = {
+            ...invisibleContext,
+            frames() {
+                return [frameContext];
+            },
+            async waitForTimeout() {
+                throw new Error('should not wait once iframe Start is visible');
+            },
+        };
+
+        await expect(autoConfirmPlan(page, 70_000)).resolves.toBe(true);
+        expect(clicked).toEqual(['button:has-text("Start")']);
+    });
+
+    it('uses the live-observed post-submit confirmation window and labels', () => {
         expect(chatgptDeepResearchSrc).toContain('button:has-text("Start research")');
         expect(chatgptDeepResearchSrc).toContain('button:has-text("Start")');
         expect(chatgptDeepResearchSrc).toContain('button:has-text("시작")');
-        expect(chatgptDeepResearchSrc).toContain('timeoutMs = 15_000');
+        expect(chatgptDeepResearchSrc).toContain('timeoutMs = 70_000');
+        expect(chatgptDeepResearchSrc).toContain('page.frames()');
         expect(chatgptDeepResearchSrc).toContain('await page.waitForTimeout(250)');
     });
 });

--- a/test/unit/web-ai-chatgpt-model.test.mjs
+++ b/test/unit/web-ai-chatgpt-model.test.mjs
@@ -21,6 +21,17 @@ describe('web-ai ChatGPT model selector policy', () => {
         expect(modelSrc).toContain('readActiveModelPill');
     });
 
+    it('does not touch the model selector without explicit model or effort flags', async () => {
+        const { selectChatGptModel } = await import('../../web-ai/chatgpt-model.mjs');
+        const page = new Proxy({}, {
+            get() {
+                throw new Error('page should not be touched without model requests');
+            },
+        });
+
+        await expect(selectChatGptModel(page, undefined, {})).resolves.toBeNull();
+    });
+
     it('normalizes observed ChatGPT effort aliases', async () => {
         const {
             CHATGPT_MODEL_EFFORT_OPTIONS,

--- a/test/unit/web-ai-chatgpt-model.test.mjs
+++ b/test/unit/web-ai-chatgpt-model.test.mjs
@@ -12,6 +12,12 @@ describe('web-ai ChatGPT model selector policy', () => {
         expect(modelSrc).toContain('Heavy');
         expect(modelSrc).toContain('Extra High');
         expect(modelSrc).toContain('Pro Extended');
+        expect(modelSrc).toContain('즉시');
+        expect(modelSrc).toContain('중간');
+        expect(modelSrc).toContain('높음');
+        expect(modelSrc).toContain('매우 높음');
+        expect(modelSrc).toContain('Pro 확장');
+        expect(modelSrc).toContain('composer-intelligence-pro-thinking-effort-trigger');
         expect(modelSrc).toContain('readActiveModelPill');
     });
 

--- a/test/unit/web-ai-chatgpt-tools.test.mjs
+++ b/test/unit/web-ai-chatgpt-tools.test.mjs
@@ -1,8 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveChatGptComposerToolRequests } from '../../web-ai/chatgpt-tools.mjs';
+import { resolveChatGptComposerToolRequests, selectChatGptComposerTools } from '../../web-ai/chatgpt-tools.mjs';
 
 describe('web-ai ChatGPT composer tool resolver', () => {
+    it('does not touch ChatGPT composer menus without explicit tool requests', async () => {
+        const page = new Proxy({}, {
+            get() {
+                throw new Error('page should not be touched without tool requests');
+            },
+        });
+
+        await expect(selectChatGptComposerTools(page)).resolves.toBeNull();
+        await expect(selectChatGptComposerTools(page, { prompt: '최신 뉴스를 요약해줘' })).resolves.toBeNull();
+    });
+
     it('normalizes explicit tool and plugin aliases', () => {
         expect(resolveChatGptComposerToolRequests({
             tools: ['web-search', '이미지 만들기'],

--- a/test/unit/web-ai-chatgpt-tools.test.mjs
+++ b/test/unit/web-ai-chatgpt-tools.test.mjs
@@ -57,14 +57,14 @@ describe('web-ai ChatGPT composer tool resolver', () => {
         });
     });
 
-    it('infers obvious tools and plugins from Korean and English prompts', () => {
+    it('infers obvious non-auth tools from Korean and English prompts', () => {
         expect(resolveChatGptComposerToolRequests({
             autoTools: true,
             prompt: '최신 GitHub repo 상태를 웹에서 확인해줘',
         })).toMatchObject({
             tools: ['web-search'],
-            plugins: ['github'],
-            reasons: ['auto:web-search-intent', 'auto:github-intent'],
+            plugins: [],
+            reasons: ['auto:web-search-intent'],
         });
 
         expect(resolveChatGptComposerToolRequests({
@@ -81,8 +81,17 @@ describe('web-ai ChatGPT composer tool resolver', () => {
             prompt: 'Supabase RLS migration을 심층 리서치해줘',
         })).toMatchObject({
             tools: ['deep-research'],
-            plugins: ['supabase'],
-            reasons: ['auto:deep-research-intent', 'auto:supabase-intent'],
+            plugins: [],
+            reasons: ['auto:deep-research-intent'],
+        });
+
+        expect(resolveChatGptComposerToolRequests({
+            autoTools: true,
+            prompt: 'GitHub repo와 Supabase RLS migration을 확인해줘',
+        })).toMatchObject({
+            tools: [],
+            plugins: [],
+            reasons: [],
         });
     });
 });

--- a/test/unit/web-ai-chatgpt-tools.test.mjs
+++ b/test/unit/web-ai-chatgpt-tools.test.mjs
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { resolveChatGptComposerToolRequests, selectChatGptComposerTools } from '../../web-ai/chatgpt-tools.mjs';
+
+const chatgptSrc = readFileSync(join(process.cwd(), 'web-ai', 'chatgpt.mjs'), 'utf8');
 
 describe('web-ai ChatGPT composer tool resolver', () => {
     it('does not touch ChatGPT composer menus without explicit tool requests', async () => {
@@ -12,6 +16,14 @@ describe('web-ai ChatGPT composer tool resolver', () => {
 
         await expect(selectChatGptComposerTools(page)).resolves.toBeNull();
         await expect(selectChatGptComposerTools(page, { prompt: '최신 뉴스를 요약해줘' })).resolves.toBeNull();
+    });
+
+    it('selects composer tools only after the composer is ready', () => {
+        const readyIndex = chatgptSrc.indexOf('await readinessAdapter.waitForReady();');
+        const toolsIndex = chatgptSrc.indexOf('const selectedTools = await selectChatGptComposerTools(page, input);');
+
+        expect(readyIndex).toBeGreaterThan(-1);
+        expect(toolsIndex).toBeGreaterThan(readyIndex);
     });
 
     it('normalizes explicit tool and plugin aliases', () => {

--- a/test/unit/web-ai-chatgpt-tools.test.mjs
+++ b/test/unit/web-ai-chatgpt-tools.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveChatGptComposerToolRequests } from '../../web-ai/chatgpt-tools.mjs';
+
+describe('web-ai ChatGPT composer tool resolver', () => {
+    it('normalizes explicit tool and plugin aliases', () => {
+        expect(resolveChatGptComposerToolRequests({
+            tools: ['web-search', '이미지 만들기'],
+            plugins: ['GitHub', 'google drive', 'Supabase'],
+        })).toMatchObject({
+            tools: ['web-search', 'image'],
+            plugins: ['github', 'google-drive', 'supabase'],
+        });
+    });
+
+    it('maps command flags to composer tools', () => {
+        expect(resolveChatGptComposerToolRequests({ webSearch: true })).toMatchObject({
+            tools: ['web-search'],
+            reasons: ['flag:web-search'],
+        });
+        expect(resolveChatGptComposerToolRequests({ outputImage: './out.png' })).toMatchObject({
+            tools: ['image'],
+            reasons: ['flag:output-image'],
+        });
+        expect(resolveChatGptComposerToolRequests({ research: 'deep' })).toMatchObject({
+            tools: ['deep-research'],
+            reasons: ['flag:research-deep'],
+        });
+    });
+
+    it('infers obvious tools and plugins from Korean and English prompts', () => {
+        expect(resolveChatGptComposerToolRequests({
+            autoTools: true,
+            prompt: '최신 GitHub repo 상태를 웹에서 확인해줘',
+        })).toMatchObject({
+            tools: ['web-search'],
+            plugins: ['github'],
+            reasons: ['auto:web-search-intent', 'auto:github-intent'],
+        });
+
+        expect(resolveChatGptComposerToolRequests({
+            autoTools: true,
+            prompt: 'MINDECODE 일러스트 이미지를 만들어줘',
+        })).toMatchObject({
+            tools: ['image'],
+            plugins: [],
+            reasons: ['auto:image-intent'],
+        });
+
+        expect(resolveChatGptComposerToolRequests({
+            autoTools: true,
+            prompt: 'Supabase RLS migration을 심층 리서치해줘',
+        })).toMatchObject({
+            tools: ['deep-research'],
+            plugins: ['supabase'],
+            reasons: ['auto:deep-research-intent', 'auto:supabase-intent'],
+        });
+    });
+});

--- a/test/unit/web-ai-chatgpt-tools.test.mjs
+++ b/test/unit/web-ai-chatgpt-tools.test.mjs
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { resolveChatGptComposerToolRequests, selectChatGptComposerTools } from '../../web-ai/chatgpt-tools.mjs';
 
 const chatgptSrc = readFileSync(join(process.cwd(), 'web-ai', 'chatgpt.mjs'), 'utf8');
+const chatgptToolsSrc = readFileSync(join(process.cwd(), 'web-ai', 'chatgpt-tools.mjs'), 'utf8');
 
 describe('web-ai ChatGPT composer tool resolver', () => {
     it('does not touch ChatGPT composer menus without explicit tool requests', async () => {
@@ -24,6 +25,11 @@ describe('web-ai ChatGPT composer tool resolver', () => {
 
         expect(readyIndex).toBeGreaterThan(-1);
         expect(toolsIndex).toBeGreaterThan(readyIndex);
+    });
+
+    it('does not clear selected composer tools with a second Escape', () => {
+        expect(chatgptToolsSrc).toContain('Search, click to remove');
+        expect(chatgptToolsSrc).not.toContain('for (let i = 0; i < 2; i += 1)');
     });
 
     it('normalizes explicit tool and plugin aliases', () => {

--- a/web-ai/chatgpt-deep-research.mjs
+++ b/web-ai/chatgpt-deep-research.mjs
@@ -125,20 +125,34 @@ async function activateDeepResearchMode(page) {
 
 /**
  * Auto-confirm the research plan if a confirm button appears.
+ * ChatGPT renders the post-submit Deep Research plan card inside the
+ * Deep Research app iframe, so scan both the page and child frames.
  * @param {any} page
  * @param {number} timeoutMs
  * @returns {Promise<boolean>}
  */
-export async function autoConfirmPlan(page, timeoutMs = 15_000) {
+export async function autoConfirmPlan(page, timeoutMs = 70_000) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-        for (const sel of DEEP_RESEARCH_SELECTORS.confirmButton) {
-            const btn = page.locator(sel).first();
-            if (await btn.isVisible().catch(() => false)) {
-                await btn.click();
-                return true;
+        const contexts = [page];
+        if (typeof page.frames === 'function') {
+            contexts.push(...page.frames());
+        }
+
+        for (const context of contexts) {
+            for (const sel of DEEP_RESEARCH_SELECTORS.confirmButton) {
+                const locator = context.locator?.(sel);
+                const btn = typeof locator?.first === 'function' ? locator.first() : locator;
+                if (!btn || typeof btn.isVisible !== 'function' || typeof btn.click !== 'function') {
+                    continue;
+                }
+                if (await btn.isVisible().catch(() => false)) {
+                    await btn.click();
+                    return true;
+                }
             }
         }
+
         await page.waitForTimeout(250);
     }
     return false;

--- a/web-ai/chatgpt-deep-research.mjs
+++ b/web-ai/chatgpt-deep-research.mjs
@@ -33,6 +33,8 @@ const DEEP_RESEARCH_SELECTORS = {
     confirmButton: [
         'button[data-testid="deep-research-confirm"]',
         'button:has-text("Start research")',
+        'button:has-text("Start")',
+        'button:has-text("시작")',
         'button:has-text("Confirm")',
     ],
     blockIndicator: [
@@ -127,7 +129,7 @@ async function activateDeepResearchMode(page) {
  * @param {number} timeoutMs
  * @returns {Promise<boolean>}
  */
-async function autoConfirmPlan(page, timeoutMs = 10_000) {
+export async function autoConfirmPlan(page, timeoutMs = 15_000) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
         for (const sel of DEEP_RESEARCH_SELECTORS.confirmButton) {
@@ -137,7 +139,7 @@ async function autoConfirmPlan(page, timeoutMs = 10_000) {
                 return true;
             }
         }
-        await page.waitForTimeout(500);
+        await page.waitForTimeout(250);
     }
     return false;
 }

--- a/web-ai/chatgpt-deep-research.mjs
+++ b/web-ai/chatgpt-deep-research.mjs
@@ -185,15 +185,15 @@ async function extractResearchReport(page, deps) {
  * Execute a Deep Research query in ChatGPT.
  * @param {any} page
  * @param {any} deps
- * @param {{ prompt: string, session: any, timeoutMs?: number }} opts
+ * @param {{ prompt: string, session: any, timeoutMs?: number, skipModeActivation?: boolean }} opts
  * @returns {Promise<DeepResearchResult>}
  */
-export async function sendDeepResearch(page, deps, { prompt, session, timeoutMs = 1_200_000 }) {
+export async function sendDeepResearch(page, deps, { prompt, session, timeoutMs = 1_200_000, skipModeActivation = false }) {
     const warnings = [];
 
     updateSession(session.sessionId, { researchMode: 'deep' });
 
-    const modeActivated = await activateDeepResearchMode(page);
+    const modeActivated = skipModeActivation ? true : await activateDeepResearchMode(page);
     if (!modeActivated) {
         warnings.push('deep-research-mode-button-not-found-using-prompt-prefix');
     }

--- a/web-ai/chatgpt-model.mjs
+++ b/web-ai/chatgpt-model.mjs
@@ -35,9 +35,10 @@ const CHATGPT_COMPOSER_MODEL_PILL_SELECTORS = [
 ];
 
 const CHATGPT_MODEL_MENU_ITEM_SELECTOR = '[data-testid^="model-switcher-gpt-"]';
-const CHATGPT_MODEL_TEXT_BUTTON_PATTERN = /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b)/i;
+const CHATGPT_MODEL_TEXT_BUTTON_PATTERN = /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b|즉시|중간|높음|매우 높음|Pro 확장|프로 확장)/i;
 const CHATGPT_OBSERVED_PRO_PILL_LABELS = ['Standard Pro', 'Extended Pro'];
 const CHATGPT_EFFORT_TRIGGER_SELECTORS = [
+    '[data-testid="composer-intelligence-pro-thinking-effort-trigger"]',
     '[data-testid*="thinking-effort"]',
     '[data-testid*="reasoning-effort"]',
     '[data-testid*="effort"]',
@@ -49,9 +50,9 @@ const CHATGPT_EFFORT_TRIGGER_SELECTORS = [
 
 /** @type {Readonly<Record<ModelChoice, ModelOptionConfig>>} */
 export const CHATGPT_MODEL_OPTIONS = {
-    instant: { testIds: ['model-switcher-gpt-5-5', 'model-switcher-gpt-5-3'], labels: ['Instant'] },
-    thinking: { testIds: ['model-switcher-gpt-5-5-thinking', 'model-switcher-gpt-5-5-thinking-thinking-effort'], labels: ['Thinking', 'Medium', 'High', 'Extra High'] },
-    pro: { testIds: ['model-switcher-gpt-5-5-pro', 'model-switcher-gpt-5-5-pro-thinking-effort'], labels: ['Pro', 'Heavy', 'Pro Standard', 'Pro Extended'] },
+    instant: { testIds: ['model-switcher-gpt-5-5', 'model-switcher-gpt-5-3'], labels: ['Instant', '즉시'] },
+    thinking: { testIds: ['model-switcher-gpt-5-5-thinking', 'model-switcher-gpt-5-5-thinking-thinking-effort'], labels: ['Thinking', 'Medium', 'High', 'Extra High', '중간', '높음', '매우 높음'] },
+    pro: { testIds: ['model-switcher-gpt-5-5-pro', 'model-switcher-gpt-5-5-pro-thinking-effort'], labels: ['Pro', 'Heavy', 'Pro Standard', 'Pro Extended', 'Pro 확장', '프로 확장'] },
 };
 
 /** @type {Readonly<Record<string, EffortConfig>>} */
@@ -77,25 +78,25 @@ export const CHATGPT_MODEL_EFFORT_OPTIONS = {
 /** @type {Readonly<Record<ModelChoice, { defaultLabels: readonly string[], efforts: Readonly<Record<string, readonly string[]>> }>>} */
 const CHATGPT_SIMPLIFIED_INTELLIGENCE_OPTIONS = {
     instant: {
-        defaultLabels: ['Instant'],
+        defaultLabels: ['Instant', '즉시'],
         efforts: {
-            light: ['Instant'],
+            light: ['Instant', '즉시'],
         },
     },
     thinking: {
-        defaultLabels: ['Medium'],
+        defaultLabels: ['Medium', '중간'],
         efforts: {
-            light: ['Instant'],
-            standard: ['Medium'],
-            extended: ['High'],
-            heavy: ['Extra High'],
+            light: ['Instant', '즉시'],
+            standard: ['Medium', '중간'],
+            extended: ['High', '높음'],
+            heavy: ['Extra High', '매우 높음'],
         },
     },
     pro: {
-        defaultLabels: ['Pro Extended'],
+        defaultLabels: ['Pro Extended', 'Pro 확장', '프로 확장'],
         efforts: {
-            standard: ['Pro Extended'],
-            extended: ['Pro Extended'],
+            standard: ['Pro Extended', 'Pro 확장', '프로 확장'],
+            extended: ['Pro Extended', 'Pro 확장', '프로 확장'],
         },
     },
 };
@@ -679,9 +680,9 @@ async function findEffortTriggerBoxNearModelRow(page, model) {
          * @param {string[]} labelsForChoice
          */
         function matchesModelText(text, choice, labelsForChoice) {
-            if (choice === 'instant') return /\b(Instant|Fast)\b/i.test(text);
-            if (choice === 'thinking') return /\b(Thinking|Think)\b/i.test(text);
-            if (choice === 'pro') return /\b(Pro|Heavy)\b/i.test(text);
+            if (choice === 'instant') return /\b(Instant|Fast)\b|즉시/i.test(text);
+            if (choice === 'thinking') return /\b(Thinking|Think)\b|중간|높음|매우 높음/i.test(text);
+            if (choice === 'pro') return /\b(Pro|Heavy)\b|Pro 확장|프로 확장/i.test(text);
             return labelsForChoice.some(label => new RegExp(`(^|\\s)${label}\\b`, 'i').test(text));
         }
     }, { expectedLabels: labels, modelChoice: model, triggerSelectors: CHATGPT_EFFORT_TRIGGER_SELECTORS }).catch(() => null);
@@ -897,7 +898,7 @@ async function isModelMenuOpen(page) {
             const testId = item.getAttribute?.('data-testid') || '';
             if (!text) return false;
             if (testId.includes('effort') && /^(Light|Standard|Extended|Heavy|Standard Pro|Extended Pro)$/i.test(text)) return false;
-            return /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b)/i.test(text);
+            return /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b|즉시|중간|높음|매우 높음|Pro 확장|프로 확장)/i.test(text);
         }))
         .catch(() => false);
     if (legacyOpen || await isSimplifiedIntelligenceMenuOpen(page, null, null)) return true;
@@ -914,9 +915,9 @@ async function isModelMenuOpen(page) {
  * @returns {RegExp}
  */
 function modelLabelPattern(choice, label) {
-    if (choice === 'instant') return /\b(Instant|Fast)\b/i;
-    if (choice === 'thinking') return /\b(Thinking|Think|Medium|High|Extra High)\b/i;
-    if (choice === 'pro') return /\b(Pro|Heavy|Pro Standard|Pro Extended)\b/i;
+    if (choice === 'instant') return /\b(Instant|Fast)\b|즉시/i;
+    if (choice === 'thinking') return /\b(Thinking|Think|Medium|High|Extra High)\b|중간|높음|매우 높음/i;
+    if (choice === 'pro') return /\b(Pro|Heavy|Pro Standard|Pro Extended)\b|Pro 확장|프로 확장/i;
     return new RegExp(`(^|\\s)${escapeRegExp(label)}\\b`, 'i');
 }
 
@@ -933,10 +934,10 @@ function effortLabelPattern(label) {
  * @returns {ModelChoice | null}
  */
 function modelChoiceFromText(text) {
-    if (/\b(Instant|Fast)\b/i.test(text)) return 'instant';
+    if (/\b(Instant|Fast)\b|즉시/i.test(text)) return 'instant';
     if (isLegacyProModelLabel(text)) return null;
-    if (/\b(Pro Standard|Pro Extended)\b/i.test(text)) return 'pro';
-    if (/\b(Medium|High|Extra High)\b/i.test(text)) return 'thinking';
+    if (/\b(Pro Standard|Pro Extended)\b|Pro 확장|프로 확장/i.test(text)) return 'pro';
+    if (/\b(Medium|High|Extra High)\b|중간|높음|매우 높음/i.test(text)) return 'thinking';
     if (/\b(Thinking|Think)\b/i.test(text)) return 'thinking';
     if (/\b(Pro|Heavy)\b/i.test(text)) return 'pro';
     return null;
@@ -968,11 +969,11 @@ async function findOptionByExactLabels(page, labels) {
 async function isSimplifiedIntelligenceMenuOpen(page, model, effort) {
     const requiredLabels = effort && model
         ? simplifiedEffortLabels(model, effort)
-        : ['Instant', 'Medium', 'High', 'Extra High'];
+        : ['Instant', 'Medium', 'High', 'Extra High', '즉시', '중간', '높음', '매우 높음'];
     if (requiredLabels.length === 0) return false;
     return page.locator('[role="menu"]').evaluateAll((menus, labels) => menus.some(menu => {
         const text = /** @type {HTMLElement} */ (menu).innerText || menu.textContent || '';
-        if (!/\bIntelligence\b/i.test(text)) return false;
+        if (!/\bIntelligence\b|지능/i.test(text)) return false;
         return labels.some(label => menuTextHasExactLine(text, label));
     }), requiredLabels).catch(() => false);
 }
@@ -1028,7 +1029,7 @@ function menuTextHasExactLine(text, label) {
 function normalizeModelPickerText(text) {
     return String(text || '')
         .toLowerCase()
-        .replace(/[^a-z0-9]+/g, ' ')
+        .replace(/[^\p{L}\p{N}]+/gu, ' ')
         .replace(/\s+/g, ' ')
         .trim();
 }

--- a/web-ai/chatgpt-tools.mjs
+++ b/web-ai/chatgpt-tools.mjs
@@ -88,14 +88,6 @@ export function resolveChatGptComposerToolRequests(input = {}) {
             tools.add('web-search');
             reasons.push('auto:web-search-intent');
         }
-        if (looksLikeGitHub(prompt)) {
-            plugins.add('github');
-            reasons.push('auto:github-intent');
-        }
-        if (looksLikeSupabase(prompt)) {
-            plugins.add('supabase');
-            reasons.push('auto:supabase-intent');
-        }
     }
     return { tools: [...tools], plugins: [...plugins], reasons };
 }
@@ -312,14 +304,4 @@ function looksLikeDeepResearch(prompt) {
 /** @param {string} prompt */
 function looksLikeWebSearch(prompt) {
     return /현재|최신|오늘|요즘|뉴스|가격|시세|공식|검색|웹\s*검색|find current|latest|today|news|price|official status|cite sources/i.test(prompt);
-}
-
-/** @param {string} prompt */
-function looksLikeGitHub(prompt) {
-    return /github|깃허브|repo|repository|레포|pull request|pr\b|issue\b|branch\b/i.test(prompt);
-}
-
-/** @param {string} prompt */
-function looksLikeSupabase(prompt) {
-    return /supabase|수파베이스|rls\b|edge function|migration|postgres/i.test(prompt);
 }

--- a/web-ai/chatgpt-tools.mjs
+++ b/web-ai/chatgpt-tools.mjs
@@ -1,0 +1,324 @@
+// @ts-check
+/** @typedef {import('playwright-core').Page} Page */
+/** @typedef {import('playwright-core').Locator} Locator */
+
+const PLUS_BUTTON_SELECTORS = [
+    '[data-testid="composer-plus-btn"]',
+    'button[aria-label="파일 추가 및 기타"]',
+    'button[aria-label*="파일 추가" i]',
+    'button[aria-label*="Add" i][aria-haspopup="menu"]',
+    'button[aria-label*="Attach" i][aria-haspopup="menu"]',
+    'button[data-testid*="plus" i]',
+];
+
+const TOOL_ALIASES = new Map([
+    ['image', 'image'], ['images', 'image'], ['create-image', 'image'], ['image-create', 'image'], ['이미지', 'image'], ['이미지만들기', 'image'], ['이미지 만들기', 'image'],
+    ['deep-research', 'deep-research'], ['research', 'deep-research'], ['deep', 'deep-research'], ['심층리서치', 'deep-research'], ['심층 리서치', 'deep-research'],
+    ['web-search', 'web-search'], ['web', 'web-search'], ['search', 'web-search'], ['browse', 'web-search'], ['웹검색', 'web-search'], ['웹 검색', 'web-search'],
+    ['agent', 'agent-mode'], ['agent-mode', 'agent-mode'], ['에이전트', 'agent-mode'], ['에이전트 모드', 'agent-mode'],
+    ['todo', 'tasks',], ['tasks', 'tasks'], ['task', 'tasks'], ['할일', 'tasks'], ['할 일 만들기', 'tasks'],
+]);
+
+/** @type {Record<string, string[]>} */
+const TOOL_LABELS = {
+    image: ['이미지 만들기', 'Create image'],
+    'deep-research': ['심층 리서치', 'Deep research'],
+    'web-search': ['웹 검색', 'Web search'],
+    'agent-mode': ['에이전트 모드', 'Agent mode'],
+    tasks: ['할 일 만들기', 'Create tasks', 'Tasks'],
+};
+
+/** @type {Record<string, string[]>} */
+const PLUGIN_LABELS = {
+    canva: ['Canva'],
+    context7: ['Context7'],
+    figma: ['Figma'],
+    github: ['GitHub'],
+    gmail: ['Gmail'],
+    'google-drive': ['Google 드라이브', 'Google Drive'],
+    drive: ['Google 드라이브', 'Google Drive'],
+    'google-contacts': ['Google 주소록', 'Google Contacts'],
+    contacts: ['Google 주소록', 'Google Contacts'],
+    'google-calendar': ['Google Calendar', 'Google 캘린더'],
+    calendar: ['Google Calendar', 'Google 캘린더'],
+    'openai-platform': ['OpenAI Platform'],
+    supabase: ['Supabase'],
+    vercel: ['Vercel'],
+};
+
+/**
+ * @param {any} input
+ * @returns {{ tools: string[], plugins: string[], reasons: string[] }}
+ */
+export function resolveChatGptComposerToolRequests(input = {}) {
+    const tools = new Set();
+    const plugins = new Set();
+    const reasons = [];
+    const explicitTools = normalizeList(input.tools || input.tool || []);
+    for (const tool of explicitTools) {
+        const normalized = normalizeToolName(tool);
+        if (normalized) tools.add(normalized);
+    }
+    for (const plugin of normalizeList(input.plugins || input.plugin || [])) {
+        const normalized = normalizePluginName(plugin);
+        if (normalized) plugins.add(normalized);
+    }
+    if (input.webSearch === true) {
+        tools.add('web-search');
+        reasons.push('flag:web-search');
+    }
+    if (input.outputImage !== undefined && input.outputImage !== null && input.outputImage !== '') {
+        tools.add('image');
+        reasons.push('flag:output-image');
+    }
+    if (input.research === 'deep') {
+        tools.add('deep-research');
+        reasons.push('flag:research-deep');
+    }
+    if (input.autoTools === true) {
+        const prompt = [input.prompt, input.goal, input.question, input.context, input.constraints].filter(Boolean).join('\n').toLowerCase();
+        if (looksLikeImageGeneration(prompt)) {
+            tools.add('image');
+            reasons.push('auto:image-intent');
+        }
+        if (looksLikeDeepResearch(prompt)) {
+            tools.add('deep-research');
+            reasons.push('auto:deep-research-intent');
+        } else if (looksLikeWebSearch(prompt)) {
+            tools.add('web-search');
+            reasons.push('auto:web-search-intent');
+        }
+        if (looksLikeGitHub(prompt)) {
+            plugins.add('github');
+            reasons.push('auto:github-intent');
+        }
+        if (looksLikeSupabase(prompt)) {
+            plugins.add('supabase');
+            reasons.push('auto:supabase-intent');
+        }
+    }
+    return { tools: [...tools], plugins: [...plugins], reasons };
+}
+
+/**
+ * @param {Page} page
+ * @param {any} input
+ * @returns {Promise<{ requestedTools: string[], requestedPlugins: string[], selectedTools: string[], selectedPlugins: string[], warnings: string[], usedFallbacks: string[], reasons: string[] } | null>}
+ */
+export async function selectChatGptComposerTools(page, input = {}) {
+    const requested = resolveChatGptComposerToolRequests(input);
+    if (!requested.tools.length && !requested.plugins.length) return null;
+    /** @type {string[]} */
+    const selectedTools = [];
+    /** @type {string[]} */
+    const selectedPlugins = [];
+    /** @type {string[]} */
+    const warnings = [];
+    /** @type {string[]} */
+    const usedFallbacks = [];
+
+    for (const tool of requested.tools) {
+        const labels = TOOL_LABELS[tool] || [tool];
+        const ok = await selectMainComposerMenuItem(page, labels, usedFallbacks);
+        if (ok) selectedTools.push(tool);
+        else warnings.push(`composer tool not selected: ${tool}`);
+    }
+    for (const plugin of requested.plugins) {
+        const labels = PLUGIN_LABELS[plugin] || [plugin];
+        const ok = await selectMoreComposerMenuItem(page, labels, usedFallbacks);
+        if (ok) selectedPlugins.push(plugin);
+        else warnings.push(`composer plugin not selected: ${plugin}`);
+    }
+    await closeComposerMenus(page);
+    return {
+        requestedTools: requested.tools,
+        requestedPlugins: requested.plugins,
+        selectedTools,
+        selectedPlugins,
+        warnings,
+        usedFallbacks,
+        reasons: requested.reasons,
+    };
+}
+
+/** @param {Page} page @param {string[]} labels @param {string[]} usedFallbacks */
+async function selectMainComposerMenuItem(page, labels, usedFallbacks) {
+    await openComposerPlusMenu(page, usedFallbacks);
+    const item = await findVisibleMenuItemByLabels(page, labels);
+    if (!item) return false;
+    const before = await checkedState(item);
+    if (before === 'true') return true;
+    return clickMenuItem(page, item);
+}
+
+/** @param {Page} page @param {string[]} labels @param {string[]} usedFallbacks */
+async function selectMoreComposerMenuItem(page, labels, usedFallbacks) {
+    await openComposerPlusMenu(page, usedFallbacks);
+    const more = await findVisibleMenuItemByLabels(page, ['더 보기', 'More']);
+    if (!more) return false;
+    await more.hover({ timeout: 1_000 }).catch(() => undefined);
+    await page.waitForTimeout(250).catch(() => undefined);
+    if (!(await anyMenuItemVisible(page, labels))) {
+        await more.click({ timeout: 2_000 }).catch(() => undefined);
+        await page.waitForTimeout(400).catch(() => undefined);
+    }
+    const item = await findVisibleMenuItemByLabels(page, labels);
+    if (!item) return false;
+    if (await checkedState(item) === 'true') return true;
+    return clickMenuItem(page, item);
+}
+
+/** @param {Page} page @param {string[]} usedFallbacks */
+async function openComposerPlusMenu(page, usedFallbacks) {
+    if (await isComposerPlusMenuOpen(page)) return;
+    for (const selector of PLUS_BUTTON_SELECTORS) {
+        const loc = page.locator(selector).first();
+        if (!(await loc.isVisible().catch(() => false))) continue;
+        await loc.click({ timeout: 3_000 }).catch(async () => {
+            const box = await loc.boundingBox().catch(() => null);
+            if (box) await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+        });
+        await page.waitForTimeout(400).catch(() => undefined);
+        if (await isComposerPlusMenuOpen(page)) return;
+    }
+    usedFallbacks.push('composer-plus-shortcut');
+    await chord(page, process.platform === 'darwin' ? 'Meta+u' : 'Control+u').catch(() => undefined);
+    await page.waitForTimeout(400).catch(() => undefined);
+}
+
+/** @param {Page} page */
+async function isComposerPlusMenuOpen(page) {
+    return page.locator('[role="menu"]').evaluateAll((menus) => menus.some(menu => {
+        const text = /** @type {HTMLElement} */ (menu).innerText || menu.textContent || '';
+        return /사진 및 파일 추가|최근 파일|이미지 만들기|심층 리서치|웹 검색|Add photos|Create image|Deep research|Web search/i.test(text);
+    })).catch(() => false);
+}
+
+/** @param {Page} page @param {string[]} labels */
+async function findVisibleMenuItemByLabels(page, labels) {
+    const candidates = await page.locator('[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"]').all().catch(() => /** @type {Locator[]} */ ([]));
+    for (const candidate of candidates) {
+        if (!(await candidate.isVisible().catch(() => false))) continue;
+        const text = normalizeUiText(await candidate.innerText({ timeout: 500 }).catch(() => ''));
+        if (!text) continue;
+        if (labels.some(label => textIncludesLabel(text, label))) return candidate;
+    }
+    return null;
+}
+
+/** @param {Page} page @param {string[]} labels */
+async function anyMenuItemVisible(page, labels) {
+    return Boolean(await findVisibleMenuItemByLabels(page, labels));
+}
+
+/** @param {Locator} loc */
+async function checkedState(loc) {
+    return loc.getAttribute('aria-checked').catch(() => null);
+}
+
+/** @param {Page} page @param {Locator} item */
+async function clickMenuItem(page, item) {
+    const directClicked = await item.click({ timeout: 3_000 })
+        .then(() => true)
+        .catch(() => false);
+    if (!directClicked) {
+        const box = await item.boundingBox().catch(() => null);
+        if (!box) return false;
+        const fallbackClicked = await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
+            .then(() => true)
+            .catch(() => false);
+        if (!fallbackClicked) return false;
+    }
+    await page.waitForTimeout(400).catch(() => undefined);
+    return true;
+}
+
+/** @param {Page} page */
+async function closeComposerMenus(page) {
+    for (let i = 0; i < 2; i += 1) {
+        await page.keyboard.press('Escape').catch(() => undefined);
+        await page.waitForTimeout(150).catch(() => undefined);
+    }
+}
+
+/** @param {Page} page @param {string} combo */
+async function chord(page, combo) {
+    const parts = combo.split('+');
+    const key = parts.pop();
+    const pressed = [];
+    try {
+        for (const mod of parts) {
+            await page.keyboard.down(mod);
+            pressed.push(mod);
+        }
+        if (key) await page.keyboard.press(key);
+    } finally {
+        for (const mod of pressed.reverse()) await page.keyboard.up(mod).catch(() => undefined);
+    }
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function normalizeList(value) {
+    if (Array.isArray(value)) return value.flatMap(item => normalizeList(item));
+    if (value === undefined || value === null || value === false) return [];
+    return String(value).split(',').map(part => part.trim()).filter(Boolean);
+}
+
+/** @param {unknown} value */
+function normalizeToolName(value) {
+    const raw = String(value || '').trim();
+    const key = normalizeUiText(raw).replace(/\s+/g, '-');
+    return TOOL_ALIASES.get(key) || TOOL_ALIASES.get(normalizeUiText(raw)) || null;
+}
+
+/** @param {unknown} value */
+function normalizePluginName(value) {
+    const key = normalizeUiText(value).replace(/\s+/g, '-');
+    if (PLUGIN_LABELS[key]) return key;
+    const simple = key.replace(/^google-/, '');
+    if (PLUGIN_LABELS[simple]) return simple;
+    return key || null;
+}
+
+/** @param {unknown} text */
+function normalizeUiText(text) {
+    return String(text || '')
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}]+/gu, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/** @param {string} haystack @param {string} label */
+function textIncludesLabel(haystack, label) {
+    const normalized = normalizeUiText(label);
+    return normalized && haystack.includes(normalized);
+}
+
+/** @param {string} prompt */
+function looksLikeImageGeneration(prompt) {
+    return /\b(generate|create|draw|make)\b.*\b(image|picture|illustration|diagram|logo|poster)\b|이미지(?:를|가|로|의)?\s*(만들|생성|제작)|그림(?:을|이|으로|의)?\s*(그려|생성)|일러스트(?:를|가|로|의)?\s*(만들|생성|제작)/i.test(prompt);
+}
+
+/** @param {string} prompt */
+function looksLikeDeepResearch(prompt) {
+    return /deep research|심층\s*리서치|심층\s*조사|장문\s*조사|출처.*종합|literature review|market research/i.test(prompt);
+}
+
+/** @param {string} prompt */
+function looksLikeWebSearch(prompt) {
+    return /현재|최신|오늘|요즘|뉴스|가격|시세|공식|검색|웹\s*검색|find current|latest|today|news|price|official status|cite sources/i.test(prompt);
+}
+
+/** @param {string} prompt */
+function looksLikeGitHub(prompt) {
+    return /github|깃허브|repo|repository|레포|pull request|pr\b|issue\b|branch\b/i.test(prompt);
+}
+
+/** @param {string} prompt */
+function looksLikeSupabase(prompt) {
+    return /supabase|수파베이스|rls\b|edge function|migration|postgres/i.test(prompt);
+}

--- a/web-ai/chatgpt-tools.mjs
+++ b/web-ai/chatgpt-tools.mjs
@@ -235,10 +235,11 @@ async function clickMenuItem(page, item) {
 
 /** @param {Page} page */
 async function closeComposerMenus(page) {
-    for (let i = 0; i < 2; i += 1) {
-        await page.keyboard.press('Escape').catch(() => undefined);
-        await page.waitForTimeout(150).catch(() => undefined);
-    }
+    // ChatGPT uses a second Escape to remove the active composer tool pill
+    // (for example, Web search becomes a "Search, click to remove" pill).
+    // One Escape is enough to close an open menu without undoing selection.
+    await page.keyboard.press('Escape').catch(() => undefined);
+    await page.waitForTimeout(150).catch(() => undefined);
 }
 
 /** @param {Page} page @param {string} combo */

--- a/web-ai/chatgpt.mjs
+++ b/web-ai/chatgpt.mjs
@@ -176,7 +176,7 @@ export async function sendWebAi(deps, input = {}) {
             : renderQuestionEnvelope(envelope)
         : renderQuestionEnvelope(envelope);
     const selectedModel = await selectChatGptModel(page, input.model, { effort: input.reasoningEffort });
-    const selectedTools = await selectChatGptComposerTools(page, input);
+
     await waitForStableAssistantCount(page);
     const assistantCount = await countAssistantMessages(page);
     const baseline = saveBaseline({
@@ -221,6 +221,7 @@ export async function sendWebAi(deps, input = {}) {
     };
     const readinessAdapter = createChatGptEditorAdapter(page, editorOptions);
     await readinessAdapter.waitForReady();
+    const selectedTools = await selectChatGptComposerTools(page, input);
     const traceCtx = createTraceContext(session.sessionId);
     let tracePersisted = false;
     try {

--- a/web-ai/chatgpt.mjs
+++ b/web-ai/chatgpt.mjs
@@ -43,6 +43,7 @@ import { waitForConversationReady, isProviderUrl } from './navigation-ready.mjs'
 import { collectImages, isImageOnlyGeneratedImageChromeText } from './chatgpt-images.mjs';
 import { resolveArtifactsDir } from './session-artifacts.mjs';
 import { sendDeepResearch } from './chatgpt-deep-research.mjs';
+import { selectChatGptComposerTools } from './chatgpt-tools.mjs';
 import { buildTargetMismatchResult } from './session-target-guard.mjs';
 
 const CHATGPT_HOSTS = new Set(['chatgpt.com', 'chat.openai.com']);
@@ -175,6 +176,7 @@ export async function sendWebAi(deps, input = {}) {
             : renderQuestionEnvelope(envelope)
         : renderQuestionEnvelope(envelope);
     const selectedModel = await selectChatGptModel(page, input.model, { effort: input.reasoningEffort });
+    const selectedTools = await selectChatGptComposerTools(page, input);
     await waitForStableAssistantCount(page);
     const assistantCount = await countAssistantMessages(page);
     const baseline = saveBaseline({
@@ -295,7 +297,7 @@ export async function sendWebAi(deps, input = {}) {
             url: finalUrl,
             sessionId: session.sessionId,
             baseline,
-            usedFallbacks: [...usedFallbacks, ...(selectedModel?.usedFallbacks || [])],
+            usedFallbacks: [...usedFallbacks, ...(selectedModel?.usedFallbacks || []), ...(selectedTools?.usedFallbacks || [])],
             ...(traceSummary ? { traceSummary } : {}),
             contextPack: contextPack ? summarizeContextPack(contextPack) : undefined,
             warnings: [
@@ -304,8 +306,12 @@ export async function sendWebAi(deps, input = {}) {
                 ...(contextAttachmentPath ? [`context package attached: ${contextPack.attachments[0].displayPath}`] : []),
                 ...attachmentWarnings,
                 ...(selectedModel?.warnings || []),
+                ...(selectedTools?.warnings || []),
                 ...(selectedModel?.selected ? [`model selected: ${selectedModel.selected}${selectedModel.alreadySelected ? ' (already selected)' : ''}`] : []),
                 ...(selectedModel?.effort ? [`reasoning effort selected: ${selectedModel.effort}`] : []),
+                ...(selectedTools?.selectedTools?.length ? [`composer tools selected: ${selectedTools.selectedTools.join(', ')}`] : []),
+                ...(selectedTools?.selectedPlugins?.length ? [`composer plugins selected: ${selectedTools.selectedPlugins.join(', ')}`] : []),
+                ...(selectedTools?.reasons?.length ? [`composer tool reasons: ${selectedTools.reasons.join(', ')}`] : []),
             ],
         };
     } finally {
@@ -626,10 +632,12 @@ export async function deepResearchWebAi(deps, input = {}) {
         port: deps.getPort?.() || 9222,
     });
     const timeoutMs = Math.max(1, Number(input.timeout || 1200)) * 1000;
+    const selectedTools = await selectChatGptComposerTools(page, { ...input, research: 'deep' });
     const result = await sendDeepResearch(page, deps, {
         prompt: (/** @type {any} */ (envelope)).composerText || input.prompt,
         session,
         timeoutMs,
+        skipModeActivation: selectedTools?.selectedTools?.includes('deep-research') === true,
     });
     if (result.ok) {
         const refreshed = getSession(session.sessionId) || session;
@@ -648,7 +656,13 @@ export async function deepResearchWebAi(deps, input = {}) {
         ...result,
         vendor: envelope.vendor,
         url: page.url(),
-        usedFallbacks: [],
+        usedFallbacks: [...(selectedTools?.usedFallbacks || [])],
+        warnings: [
+            ...(result.warnings || []),
+            ...(selectedTools?.warnings || []),
+            ...(selectedTools?.selectedTools?.length ? [`composer tools selected: ${selectedTools.selectedTools.join(', ')}`] : []),
+            ...(selectedTools?.selectedPlugins?.length ? [`composer plugins selected: ${selectedTools.selectedPlugins.join(', ')}`] : []),
+        ],
     };
 }
 

--- a/web-ai/cli.mjs
+++ b/web-ai/cli.mjs
@@ -141,6 +141,8 @@ Attachments and context:
   --auto-tools                      Heuristically select ChatGPT tools/plugins
                                     from the prompt (current/news → web search,
                                     image intent → image, repo/GitHub → GitHub).
+                                    Composer menus are untouched unless one of
+                                    these tool/plugin flags requests selection.
   --output-image <path>             Save generated ChatGPT images. If several
                                     images are returned, siblings are written
                                     as out.png, out-2.png, out-3.png.

--- a/web-ai/cli.mjs
+++ b/web-ai/cli.mjs
@@ -138,11 +138,11 @@ Attachments and context:
                                     google-drive, google-calendar, supabase,
                                     vercel, figma, canva, context7.
   --web-search                      Shortcut for --tool web-search.
-  --auto-tools                      Heuristically select ChatGPT tools/plugins
+  --auto-tools                      Heuristically select non-auth ChatGPT tools
                                     from the prompt (current/news → web search,
-                                    image intent → image, repo/GitHub → GitHub).
-                                    Composer menus are untouched unless one of
-                                    these tool/plugin flags requests selection.
+                                    image intent → image, deep research intent
+                                    → deep research). Plugins/connectors require
+                                    explicit --plugin because they may open auth.
   --output-image <path>             Save generated ChatGPT images. If several
                                     images are returned, siblings are written
                                     as out.png, out-2.png, out-3.png.

--- a/web-ai/cli.mjs
+++ b/web-ai/cli.mjs
@@ -100,7 +100,7 @@ Provider:
   --vendor <name>     chatgpt | gemini | grok (default: chatgpt)
   --url <url>         Navigate or verify the provider URL before mutation
   --model <alias>     Provider model alias; aliases below
-                        ChatGPT: instant, thinking, pro  (default for chatgpt: pro)
+                        ChatGPT: instant, thinking, pro
                         Gemini  models: flash-lite, flash, pro
                         Gemini  tool:   deepthink
                         Grok:   auto, fast, expert, thinking, heavy
@@ -1490,21 +1490,15 @@ export async function ensureHeadedBrowserForWebAi(deps = {}, command, argv = [])
 }
 
 /**
- * Apply implicit defaults so the most common workflows do not require flags.
- * Currently: when targeting ChatGPT without --model, we pre-select Pro via DOM.
- * The reasoning-effort menu is intentionally NOT defaulted — it remains untouched
- * unless the user explicitly passes --effort/--reasoning-effort.
+ * Keep provider defaults non-mutating: send/query must not touch model or
+ * effort selectors unless the caller passes --model or --effort explicitly.
  *
  * @param {any} values
  * @param {string} command
  */
 function applyVendorDefaults(values, command) {
-    const commandsThatSelectModel = new Set(['send', 'query', 'render', 'context-render', 'context-dry-run']);
-    if (!commandsThatSelectModel.has(command)) return;
-    const vendor = values.vendor || 'chatgpt';
-    if (vendor === 'chatgpt' && !values.model) {
-        values.model = 'pro';
-    }
+    void values;
+    void command;
 }
 
 /**

--- a/web-ai/cli.mjs
+++ b/web-ai/cli.mjs
@@ -130,6 +130,17 @@ Attachments and context:
   --inline-only                     Required for send/query without files
   --file <path>                     Upload a file; repeat for several files of
                                     mixed types (zip + image + doc) in one turn
+  --tool <name>                     ChatGPT composer tool to select before send;
+                                    repeatable. Known: image, deep-research,
+                                    web-search, agent-mode, tasks.
+  --plugin <name>                   ChatGPT "More" plugin/tool to select;
+                                    repeatable. Known: github, gmail,
+                                    google-drive, google-calendar, supabase,
+                                    vercel, figma, canva, context7.
+  --web-search                      Shortcut for --tool web-search.
+  --auto-tools                      Heuristically select ChatGPT tools/plugins
+                                    from the prompt (current/news → web search,
+                                    image intent → image, repo/GitHub → GitHub).
   --output-image <path>             Save generated ChatGPT images. If several
                                     images are returned, siblings are written
                                     as out.png, out-2.png, out-3.png.
@@ -332,12 +343,6 @@ Artifact options:
   --multi-zip           Retrieve several named /mnt/data/*.zip artifacts.
   --output-dir <dir>    Save multi-zip artifacts into this directory.
                         Default: ./code-artifacts-<conversation>/.
-  --context-refresh     Re-upload the dev-agent context zip on a continuation
-                        turn. By default it is attached only on the FIRST turn
-                        of a conversation; continuation turns (--url /
-                        --conversation / --session) skip it because the
-                        container /mnt and conversation history already carry
-                        the contract.
 
 Optional inputs:
   --file <path>         Repeatable upload; may mix zip, image, PDF, docs, text.
@@ -345,6 +350,10 @@ Optional inputs:
   --context-exclude <glob>
   --context-file <path>
   --context-transport <upload|inline>
+  --context-refresh     Re-upload the dev-agent context zip on a continuation
+                        turn. By default it is attached only on the FIRST turn
+                        of a conversation; continuation turns (--url /
+                        --conversation / --session) skip it.
 
 Behavior:
   New code artifacts must include PLAN.md or 00_plan.md at the zip root.
@@ -530,6 +539,10 @@ async function runWebAiCliInner(argv = [], deps) {
             'source-audit-scope': { type: 'string' },
             'source-audit-date': { type: 'string' },
             file: { type: 'string', multiple: true },
+            tool: { type: 'string', multiple: true },
+            plugin: { type: 'string', multiple: true },
+            'web-search': { type: 'boolean', default: false },
+            'auto-tools': { type: 'boolean', default: false },
             'output-image': { type: 'string' },
             'output-zip': { type: 'string' },
             'output-dir': { type: 'string' },
@@ -619,6 +632,10 @@ async function runWebAiCliInner(argv = [], deps) {
         attachmentPolicy: filePaths.length ? 'upload' : 'inline-only',
         filePath: filePaths[0],
         filePaths,
+        tools: values.tool || [],
+        plugins: values.plugin || [],
+        webSearch: values['web-search'] === true,
+        autoTools: values['auto-tools'] === true,
         outputImage: values['output-image'],
         outputZip: values['output-zip'],
         outputDir: values['output-dir'],


### PR DESCRIPTION
## Summary
- add ChatGPT composer `+` menu automation for tools/plugins (`--tool`, `--plugin`, `--web-search`, `--auto-tools`)
- support observed Korean ChatGPT Intelligence UI labels for model/effort selection (`즉시`, `중간`, `높음`, `매우 높음`, `Pro 확장`)
- document composer tools/plugins in the bundled `web-ai` skill
- preserve existing `--context-refresh` code-mode behavior while adding the new flags

## Verification
- `node --check web-ai/chatgpt-model.mjs web-ai/chatgpt-tools.mjs web-ai/chatgpt-deep-research.mjs web-ai/chatgpt.mjs web-ai/cli.mjs`
- `npm run -s typecheck:checkjs`
- `npm run -s smoke:bins`
- `npm run -s test:unit` (102 files / 811 tests)
- `git diff --cached --check`
- added-line security scan: no findings
- independent pre-commit review: passed
