### PR TITLE
fix(web-ai): make attachment upload timeout configurable

### DIFF
--- a/test/integration/web-ai-cli-contract.test.mjs
+++ b/test/integration/web-ai-cli-contract.test.mjs
@@ -28,6 +28,7 @@ describe('web-ai CLI contract', () => {
         expect(result.stdout).toContain("Keeps Deep Research's default source state");
         expect(result.stdout).toContain('Apps/Sites/connectors are not configured');
         expect(result.stdout).toContain('--max-upload-file-size <bytes>');
+        expect(result.stdout).toContain('--attachment-upload-timeout-ms <ms>');
         expect(result.stdout).toContain('--max-context-file-size <bytes>');
         expect(result.stdout).toContain('out.png, out-2.png, out-3.png');
         expect(result.stdout).toContain('query --session <id> sends a new prompt');

--- a/test/integration/web-ai-mcp-server.test.mjs
+++ b/test/integration/web-ai-mcp-server.test.mjs
@@ -45,6 +45,7 @@ describe('web-ai MCP server', () => {
         expect(submitPrompt.inputSchema.properties.filePath.type).toBe('string');
         expect(submitPrompt.inputSchema.properties.reasoningEffort.type).toBe('string');
         expect(submitPrompt.inputSchema.properties.maxUploadFileSize.type).toBe('number');
+        expect(submitPrompt.inputSchema.properties.attachmentUploadTimeoutMs.type).toBe('number');
         expect(submitPrompt.description).toContain('generated image output');
         expect(submitPrompt.description).toContain('CLI-only/deferred');
         const waitResponse = listed.result.tools.find(tool => tool.name === 'web_ai_wait_response');

--- a/test/unit/chatgpt-attachments.test.mjs
+++ b/test/unit/chatgpt-attachments.test.mjs
@@ -11,6 +11,7 @@ import {
     sendButtonTimeoutMs,
     UPLOAD_BUTTON_SELECTORS,
 } from '../../web-ai/chatgpt-attachments.mjs';
+import { resolveAttachmentUploadTimeoutMs } from '../../web-ai/chatgpt-upload-surface.mjs';
 
 describe('ChatGPT attachment upload surface', () => {
     it('tracks the current ChatGPT plus button label for upload capability probes', () => {
@@ -56,6 +57,20 @@ describe('ChatGPT attachment upload surface', () => {
         expect(page.filePath).toBe('/tmp/context.txt');
     });
 
+    it('passes explicit upload timeout through upload-menu file chooser', async () => {
+        const page = createUploadPage({ twoStepUploadMenu: true, menuItemFileChooser: true });
+        const result = await attachLocalFileLive(page, {
+            path: '/tmp/context.txt',
+            basename: 'context.txt',
+            sizeBytes: 12,
+        }, {
+            attachmentUploadTimeoutMs: 123_456,
+        });
+
+        expect(result.ok).toBe(true);
+        expect(page.fileTimeout).toBe(123_456);
+    });
+
     it('uploads several mixed-type files through one setInputFiles array', async () => {
         const page = createUploadPage();
         const result = await attachLocalFilesLive(page, [
@@ -68,6 +83,20 @@ describe('ChatGPT attachment upload surface', () => {
         expect(result.stage).toBe('attachment-uploaded');
         // all three paths handed to setInputFiles in one call
         expect(page.filePath).toEqual(['/tmp/backend.zip', '/tmp/pixel.png', '/tmp/notes.txt']);
+    });
+
+    it('passes explicit upload timeout through direct batch setInputFiles', async () => {
+        const page = createUploadPage();
+        const result = await attachLocalFilesLive(page, [
+            { path: '/tmp/backend.zip', basename: 'backend.zip', sizeBytes: 200 },
+            { path: '/tmp/notes.txt', basename: 'notes.txt', sizeBytes: 12 },
+        ], {
+            uploadTarget: { selector: 'button[aria-label*="Attach" i]', resolution: 'css-fallback' },
+            attachmentUploadTimeoutMs: 98_765,
+        });
+
+        expect(result.ok).toBe(true);
+        expect(page.fileTimeout).toBe(98_765);
     });
 
     it('delegates a single-element batch to the single-file path', async () => {
@@ -118,6 +147,21 @@ describe('ChatGPT attachment upload surface', () => {
         expect(sendButtonTimeoutMs(['context.pdf'])).toBe(45_000);
     });
 
+    it('resolves attachment upload timeout from explicit value or env fallback', () => {
+        const previous = process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS;
+        try {
+            delete process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS;
+            expect(resolveAttachmentUploadTimeoutMs(null)).toBe(60_000);
+            process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS = '77777';
+            expect(resolveAttachmentUploadTimeoutMs(undefined)).toBe(77_777);
+            expect(resolveAttachmentUploadTimeoutMs('88888')).toBe(88_888);
+            expect(resolveAttachmentUploadTimeoutMs('invalid')).toBe(60_000);
+        } finally {
+            if (previous === undefined) delete process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS;
+            else process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS = previous;
+        }
+    });
+
     it('builds scoped attachment readiness expression with nested label and count fallback terms', () => {
         const expression = buildAttachmentReadyExpression(['context.pdf']);
         expect(expression).toContain('Remove attachment');
@@ -134,6 +178,7 @@ function createUploadPage(options = {}) {
         clickedMenuItem: null,
         fileInputAvailable: false,
         filePath: null,
+        fileTimeout: null,
         chipVisible: false,
         menuOpen: false,
         waitedForFileChooser: false,
@@ -177,9 +222,10 @@ function createUploadLocator(page, selector) {
             if (page.twoStepUploadMenu && selector.includes('plus')) page.menuOpen = true;
             else page.fileInputAvailable = true;
         },
-        setInputFiles: async filePath => {
+        setInputFiles: async (filePath, options = {}) => {
             if (!isFileInput) throw new Error('not a file input');
             page.filePath = filePath;
+            page.fileTimeout = options.timeout;
             page.chipVisible = true;
         },
     };
@@ -194,8 +240,9 @@ function createUploadMenuItemLocator(page) {
             page.menuOpen = false;
             if (page.menuItemFileChooser && page.pendingFileChooser) {
                 page.pendingFileChooser({
-                    setFiles: async filePath => {
+                    setFiles: async (filePath, options = {}) => {
                         page.filePath = filePath;
+                        page.fileTimeout = options.timeout;
                         page.chipVisible = true;
                     },
                 });

--- a/test/unit/web-ai-tool-schema.test.mjs
+++ b/test/unit/web-ai-tool-schema.test.mjs
@@ -32,6 +32,7 @@ describe('web-ai MCP tool schema', () => {
         const submit = toolSchemaForMcp('web_ai_submit_prompt');
         expect(submit.description).toContain('CLI-only/deferred');
         expect(submit.inputSchema.properties.maxUploadFileSize).toMatchObject({ type: 'number', minimum: 1 });
+        expect(submit.inputSchema.properties.attachmentUploadTimeoutMs).toMatchObject({ type: 'number', minimum: 1 });
         expect(toolSchemaForMcp('web_ai_wait_response').description).toContain('recoverable timeout');
         expect(toolSchemaForMcp('web_ai_wait_response').description).toContain('sessionId');
         expect(toolSchemaForMcp('web_ai_session_resume').description).toContain('session-bound recovery');

--- a/test/unit/web-ai-tool-validation.test.mjs
+++ b/test/unit/web-ai-tool-validation.test.mjs
@@ -36,6 +36,7 @@ describe('web-ai tool input validation', () => {
             filePath: '/tmp/context.txt',
             reasoningEffort: 'high',
             maxUploadFileSize: 1024,
+            attachmentUploadTimeoutMs: 120000,
             policy: { version: 1 },
         })).toBe(true);
     });

--- a/web-ai/chatgpt-attachments.mjs
+++ b/web-ai/chatgpt-attachments.mjs
@@ -9,6 +9,7 @@ import {
     isImageAttachmentPath,
     scoreFileInputCandidate,
     setFilesViaUploadSurface,
+    resolveAttachmentUploadTimeoutMs,
 } from './chatgpt-upload-surface.mjs';
 
 /** @typedef {import('playwright-core').Page} Page */
@@ -71,6 +72,7 @@ import {
  * @property {AttachmentTarget|null} [uploadTarget]
  * @property {number|string|null} [maxUploadBytes]
  * @property {number|string|null} [maxImageBytes]
+ * @property {number|string|null} [attachmentUploadTimeoutMs]
  */
 
 const HARD_LIMIT_BYTES = 512 * 1024 * 1024;
@@ -226,16 +228,17 @@ export async function attachLocalFileLive(page, file, options = {}) {
         return { ok: false, stage: 'attachment-preflight', error: preflight.rejectedReason || 'preflight rejected', usedFallbacks };
     }
     warnings.push(...preflight.softWarnings);
+    const uploadTimeoutMs = resolveAttachmentUploadTimeoutMs(options.attachmentUploadTimeoutMs);
 
     const inputSel = await findFirstFileInput(page, file);
     if (inputSel) {
         try {
-            await page.locator(inputSel).first().setInputFiles(file.path, { timeout: 10_000 });
+            await page.locator(inputSel).first().setInputFiles(file.path, { timeout: uploadTimeoutMs });
         } catch (e) {
             return { ok: false, stage: 'attachment-upload', error: `setInputFiles failed: ${/** @type {{message?: string}} */ (e)?.message}`, usedFallbacks };
         }
     } else {
-        const surfaceUpload = await setFilesViaUploadSurface(page, file.path, file, usedFallbacks, options.uploadTarget);
+        const surfaceUpload = await setFilesViaUploadSurface(page, file.path, file, usedFallbacks, options.uploadTarget, { uploadTimeoutMs });
         if (surfaceUpload.ok !== true) {
             return { ok: false, stage: 'attachment-upload', error: surfaceUpload.error, usedFallbacks };
         }
@@ -290,16 +293,17 @@ export async function attachLocalFilesLive(page, files, options = {}) {
     // the general (no-accept) input that takes all types.
     const batchIsImage = files.every(file => isImageAttachmentPath(file.basename || file.path || ''));
     const probeFile = { ...files[0], basename: batchIsImage ? files[0].basename : 'batch.bin' };
+    const uploadTimeoutMs = resolveAttachmentUploadTimeoutMs(options.attachmentUploadTimeoutMs);
 
     const inputSel = await findFirstFileInput(page, probeFile);
     if (inputSel) {
         try {
-            await page.locator(inputSel).first().setInputFiles(files.map(file => file.path), { timeout: 15_000 });
+            await page.locator(inputSel).first().setInputFiles(files.map(file => file.path), { timeout: uploadTimeoutMs });
         } catch (e) {
             return { ok: false, stage: 'attachment-upload', error: `setInputFiles failed: ${/** @type {{message?: string}} */ (e)?.message}`, usedFallbacks };
         }
     } else {
-        const surfaceUpload = await setFilesViaUploadSurface(page, files.map(file => file.path), probeFile, usedFallbacks, options.uploadTarget);
+        const surfaceUpload = await setFilesViaUploadSurface(page, files.map(file => file.path), probeFile, usedFallbacks, options.uploadTarget, { uploadTimeoutMs });
         if (surfaceUpload.ok !== true) {
             return { ok: false, stage: 'attachment-upload', error: surfaceUpload.error, usedFallbacks };
         }

--- a/web-ai/chatgpt-upload-surface.mjs
+++ b/web-ai/chatgpt-upload-surface.mjs
@@ -17,6 +17,11 @@ import { basename } from 'node:path';
  */
 
 /**
+ * @typedef {Object} UploadSurfaceOptions
+ * @property {number|string|null} [uploadTimeoutMs]
+ */
+
+/**
  * @typedef {Object} UploadSurfaceResultOk
  * @property {true} ok
  * @property {string} method
@@ -32,6 +37,7 @@ import { basename } from 'node:path';
 /** @typedef {UploadSurfaceResultOk | UploadSurfaceResultFail} UploadSurfaceResult */
 
 export const IMAGE_ATTACHMENT_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.heic']);
+export const DEFAULT_ATTACHMENT_UPLOAD_TIMEOUT_MS = 60_000;
 
 export const UPLOAD_BUTTON_SELECTORS = [
     '[data-testid="composer-plus-btn"]',
@@ -141,23 +147,25 @@ export async function findFirstFileInput(page, file) {
  * @param {AttachmentProbeFile} probeFile
  * @param {string[]} usedFallbacks
  * @param {AttachmentTarget|null} [uploadTarget]
+ * @param {UploadSurfaceOptions} [options]
  * @returns {Promise<UploadSurfaceResult>}
  */
-export async function setFilesViaUploadSurface(page, filePaths, probeFile, usedFallbacks, uploadTarget = null) {
+export async function setFilesViaUploadSurface(page, filePaths, probeFile, usedFallbacks, uploadTarget = null, options = {}) {
     const selectors = uploadTarget?.selector ? [uploadTarget.selector] : UPLOAD_BUTTON_SELECTORS;
+    const uploadTimeoutMs = resolveAttachmentUploadTimeoutMs(options.uploadTimeoutMs);
     let lastError = 'upload surface did not expose a file input or chooser';
     for (const selector of selectors) {
         const clicked = await clickUploadButton(page, selector, usedFallbacks);
         if (!clicked) continue;
         await page.waitForTimeout(300).catch(() => undefined);
 
-        const directInput = await setFilesOnDiscoveredInput(page, filePaths, probeFile, selector);
+        const directInput = await setFilesOnDiscoveredInput(page, filePaths, probeFile, selector, uploadTimeoutMs);
         if (directInput.ok === true) return directInput;
         lastError = directInput.error;
 
         const menuItem = await findVisibleUploadMenuItem(page);
         if (menuItem) {
-            const menuResult = await clickUploadMenuItemAndSetFiles(page, menuItem, filePaths, probeFile);
+            const menuResult = await clickUploadMenuItemAndSetFiles(page, menuItem, filePaths, probeFile, uploadTimeoutMs);
             if (menuResult.ok === true) return menuResult;
             lastError = menuResult.error;
         }
@@ -170,17 +178,30 @@ export async function setFilesViaUploadSurface(page, filePaths, probeFile, usedF
 }
 
 /**
+ * @param {unknown} value
+ * @param {number} [fallback]
+ * @returns {number}
+ */
+export function resolveAttachmentUploadTimeoutMs(value, fallback = DEFAULT_ATTACHMENT_UPLOAD_TIMEOUT_MS) {
+    const configured = value ?? process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS;
+    if (configured === undefined || configured === null || configured === '') return fallback;
+    const parsed = Number(configured);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
  * @param {Page} page
  * @param {string|string[]} filePaths
  * @param {AttachmentProbeFile} probeFile
  * @param {string} openerSelector
+ * @param {number} uploadTimeoutMs
  * @returns {Promise<UploadSurfaceResult>}
  */
-async function setFilesOnDiscoveredInput(page, filePaths, probeFile, openerSelector) {
+async function setFilesOnDiscoveredInput(page, filePaths, probeFile, openerSelector, uploadTimeoutMs) {
     const inputSel = await findFirstFileInput(page, probeFile);
     if (!inputSel) return { ok: false, error: 'composer file input not found' };
     try {
-        await page.locator(inputSel).first().setInputFiles(filePaths, { timeout: 15_000 });
+        await page.locator(inputSel).first().setInputFiles(filePaths, { timeout: uploadTimeoutMs });
         return { ok: true, method: 'input', selector: inputSel };
     } catch (e) {
         return { ok: false, error: `setInputFiles after ${openerSelector} failed: ${/** @type {{message?: string}} */ (e)?.message}` };
@@ -192,9 +213,10 @@ async function setFilesOnDiscoveredInput(page, filePaths, probeFile, openerSelec
  * @param {Locator} menuItem
  * @param {string|string[]} filePaths
  * @param {AttachmentProbeFile} probeFile
+ * @param {number} uploadTimeoutMs
  * @returns {Promise<UploadSurfaceResult>}
  */
-async function clickUploadMenuItemAndSetFiles(page, menuItem, filePaths, probeFile) {
+async function clickUploadMenuItemAndSetFiles(page, menuItem, filePaths, probeFile, uploadTimeoutMs) {
     const chooserPromise = waitForFileChooser(page);
     const clicked = await menuItem.click({ timeout: 3_000 })
         .then(() => true)
@@ -210,7 +232,7 @@ async function clickUploadMenuItemAndSetFiles(page, menuItem, filePaths, probeFi
     const chooser = await chooserPromise;
     if (chooser) {
         try {
-            await chooser.setFiles(filePaths, { timeout: 15_000 });
+            await chooser.setFiles(filePaths, { timeout: uploadTimeoutMs });
             return { ok: true, method: 'filechooser' };
         } catch (e) {
             return { ok: false, error: `filechooser.setFiles failed: ${/** @type {{message?: string}} */ (e)?.message}` };
@@ -218,7 +240,7 @@ async function clickUploadMenuItemAndSetFiles(page, menuItem, filePaths, probeFi
     }
 
     await page.waitForTimeout(300).catch(() => undefined);
-    return setFilesOnDiscoveredInput(page, filePaths, probeFile, 'upload-menu-item');
+    return setFilesOnDiscoveredInput(page, filePaths, probeFile, 'upload-menu-item', uploadTimeoutMs);
 }
 
 /**

--- a/web-ai/chatgpt.mjs
+++ b/web-ai/chatgpt.mjs
@@ -260,6 +260,7 @@ export async function sendWebAi(deps, input = {}) {
             const upload = await attachLocalFilesLive(page, uploadPaths.map(fileInfoFromPath), {
                 uploadTarget: /** @type {any} */ (uploadResolution?.target || null),
                 maxUploadBytes: input.maxUploadFileSize,
+                attachmentUploadTimeoutMs: input.attachmentUploadTimeoutMs,
             });
             if (!upload.ok) throw new WebAiError({
                 errorCode: 'provider.attachment-evidence-missing',

--- a/web-ai/cli.mjs
+++ b/web-ai/cli.mjs
@@ -172,6 +172,10 @@ Attachments and context:
                                     Apps/Sites/connectors are not configured
                                     unless a future explicit flag requests them.
   --max-upload-file-size <bytes>    Per-file live upload cap for --file.
+  --attachment-upload-timeout-ms <ms>
+                                    Timeout for browser file handoff before the
+                                    provider processes the upload. Env fallback:
+                                    AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS.
   --max-context-file-size <bytes>   Preferred name for per-file context budget.
   --context-from-files <glob|path>  Add files to a context package; repeatable
   --context-exclude <glob>          Exclude from the package; repeatable
@@ -586,6 +590,7 @@ async function runWebAiCliInner(argv = [], deps) {
             'max-file-size': { type: 'string' },
             'max-context-file-size': { type: 'string' },
             'max-upload-file-size': { type: 'string' },
+            'attachment-upload-timeout-ms': { type: 'string' },
             'files-report': { type: 'boolean', default: false },
             'context-transport': { type: 'string' },
             'trace-dir': { type: 'string' },
@@ -683,6 +688,7 @@ async function runWebAiCliInner(argv = [], deps) {
         maxInput: values['max-input'],
         maxFileSize: values['max-context-file-size'] || values['max-file-size'],
         maxUploadFileSize: values['max-upload-file-size'],
+        attachmentUploadTimeoutMs: values['attachment-upload-timeout-ms'] || process.env.AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS,
         filesReport: values['files-report'],
         contextTransport: values['context-transport'],
         inlineOnly: values['inline-only'],

--- a/web-ai/gemini-live.mjs
+++ b/web-ai/gemini-live.mjs
@@ -26,6 +26,7 @@ import { captureCopiedResponseText, GEMINI_COPY_SELECTORS, preferCopiedText } fr
 import { withAnswerArtifact } from './answer-artifact.mjs';
 import { selectGeminiModel, geminiModelCapabilityProbe } from './gemini-model.mjs';
 import { preflightAttachment } from './chatgpt-attachments.mjs';
+import { resolveAttachmentUploadTimeoutMs } from './chatgpt-upload-surface.mjs';
 import { WebAiError } from './errors.mjs';
 import { finalizeProviderTab } from './tab-finalizer.mjs';
 import { recordActiveLease } from './tab-lease-store.mjs';
@@ -216,6 +217,7 @@ export async function geminiSendWebAi(deps, input = {}) {
     if (uploadPath) {
         const uploaded = await attachGeminiLocalFileLive(page, fileInfoFromPath(uploadPath), {
             maxUploadBytes: input.maxUploadFileSize,
+            attachmentUploadTimeoutMs: input.attachmentUploadTimeoutMs,
         });
         if (!uploaded.ok) throw new WebAiError({
             errorCode: 'provider.attachment-evidence-missing',
@@ -305,7 +307,7 @@ function fileInfoFromPath(filePath) {
 /**
  * @param {any} page
  * @param {any} file
- * @param {{ maxUploadBytes?: number|string|null }} [options]
+ * @param {{ maxUploadBytes?: number|string|null, attachmentUploadTimeoutMs?: number|string|null }} [options]
  */
 async function attachGeminiLocalFileLive(page, file, options = {}) {
     /** @type {any[]} */
@@ -318,6 +320,7 @@ async function attachGeminiLocalFileLive(page, file, options = {}) {
         return { ok: false, error: preflight.rejectedReason || 'preflight rejected', usedFallbacks };
     }
     warnings.push(...preflight.softWarnings);
+    const uploadTimeoutMs = resolveAttachmentUploadTimeoutMs(options.attachmentUploadTimeoutMs);
     const uploadButton = await findFirstSelector(page, GEMINI_UPLOAD_SELECTORS, 5_000);
     if (!uploadButton) return { ok: false, error: 'gemini upload file menu button not visible', usedFallbacks };
     try {
@@ -328,7 +331,7 @@ async function attachGeminiLocalFileLive(page, file, options = {}) {
         const chooserPromise = page.waitForEvent('filechooser', { timeout: 15_000 });
         await uploadItem.click({ timeout: 5_000, force: true });
         const chooser = await chooserPromise;
-        await chooser.setFiles(file.path);
+        await chooser.setFiles(file.path, { timeout: uploadTimeoutMs });
     } catch (e) {
         usedFallbacks.push(`gemini-filechooser-failed:${(/** @type {any} */ (e)).message}`);
         return { ok: false, error: `gemini file chooser upload failed: ${(/** @type {any} */ (e)).message}`, usedFallbacks };

--- a/web-ai/grok-live.mjs
+++ b/web-ai/grok-live.mjs
@@ -168,6 +168,7 @@ export async function grokSendWebAi(deps, input = {}) {
     if (uploadPath) {
         const uploaded = await attachLocalFileLive(page, fileInfoFromPath(uploadPath), {
             maxUploadBytes: input.maxUploadFileSize,
+            attachmentUploadTimeoutMs: input.attachmentUploadTimeoutMs,
         });
         if (!uploaded.ok) throw new WebAiError({
             errorCode: 'provider.attachment-evidence-missing',

--- a/web-ai/tool-schema.mjs
+++ b/web-ai/tool-schema.mjs
@@ -62,6 +62,7 @@ export const WEB_AI_TOOLS = {
             inlineOnly: { type: 'boolean', default: true },
             timeout: { type: 'number' },
             maxUploadFileSize: { type: 'number', minimum: 1 },
+            attachmentUploadTimeoutMs: { type: 'number', minimum: 1 },
             policy: policySchema,
         }, ['prompt']),
     },


### PR DESCRIPTION
## Summary

This patch makes the browser file handoff timeout for live web-ai attachments configurable instead of hard-coded at 10-15s.

It adds:
- default attachment handoff timeout of 60s
- `--attachment-upload-timeout-ms <ms>` CLI option
- `AGBROWSE_ATTACHMENT_UPLOAD_TIMEOUT_MS` environment fallback
- MCP schema field `attachmentUploadTimeoutMs`
- plumbing through ChatGPT direct input, ChatGPT upload-surface fallback, Grok, and Gemini file chooser upload paths
- focused tests for CLI help, MCP schema/validation, explicit timeout propagation, and env fallback

## Motivation

While driving ChatGPT Pro with a large review packet, manual UI upload succeeded, but agbrowse automation failed in the file handoff layer:

- single large zip: upstream Playwright/remote-browser transfer reported a >50MB transfer limitation before ChatGPT processed the upload
- split ~40MB shard: `locator.setInputFiles` timed out at the current 10s handoff timeout

The >50MB remote transfer limitation still needs a separate strategy, but making the timeout configurable fixes the avoidable timeout path for large-but-supported shards and slower machines.

## Validation

Focused suite on a clean worktree:

```text
npm test -- --run test/unit/chatgpt-attachments.test.mjs test/unit/web-ai-tool-schema.test.mjs test/unit/web-ai-tool-validation.test.mjs test/integration/web-ai-mcp-server.test.mjs test/integration/web-ai-cli-contract.test.mjs

Test Files  5 passed (5)
Tests       57 passed (57)
```