### PR TITLE
fix(web-ai): support single Pro reasoning picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,16 +669,19 @@ agbrowse web-ai query \
 
 Model aliases:
 
-- `instant`, `fast`, `gpt-5.3`
-- `thinking`, `think`, `gpt-5.5-thinking`
-- `pro`, `gpt-5.5-pro`
+- `instant`, `fast`
+- `thinking`, `think`
+- `pro` (preferred stable alias)
+- Versioned aliases such as `gpt-5.3`, `gpt-5.5-thinking`, and `gpt-5.5-pro`
+  remain compatible but do not pin the visible model family
 
-Current headed ChatGPT UI may expose a simplified `Intelligence` picker instead
-of the older model row plus separate effort submenu. The runtime maps
-`thinking --effort light|standard|extended|heavy` to `Instant|Medium|High|Extra
-High`, and maps Pro requests through `Pro Extended` when that is the visible Pro
-entry. Legacy `model-switcher-*` rows and composer-pill fallbacks remain
-supported.
+Current headed ChatGPT UI may expose `Reasoning level` / `추론 수준` with a
+single `Pro` row and a separate visible model-family label such as
+`GPT-5.6 Sol`. Use `--model pro` without `--effort` by default. Legacy
+`--model pro --effort standard|extended` calls still select Pro; when no
+separate Pro effort control exists they return a warning and record
+`effortStatus: unsupported-by-ui`. Older `Intelligence` and
+`model-switcher-*` layouts remain supported.
 
 ### ChatGPT Code Mode
 

--- a/skills/browser/browser.mjs
+++ b/skills/browser/browser.mjs
@@ -3356,7 +3356,7 @@ try {
                                        Gemini:  flash-lite/flash/pro + tool deepthink
                                        Grok:    heavy/expert/thinking/fast/auto
         --effort <alias>               ChatGPT only; requires --model
-                                       Pro: standard/extended
+                                       Pro: standard/extended (legacy; single Pro warns/no-ops)
                                        Thinking: light/standard/extended/heavy
         --reasoning-effort <alias>     Alias for --effort
         --url <conversation-or-provider-url>

--- a/skills/web-ai/SKILL.md
+++ b/skills/web-ai/SKILL.md
@@ -656,12 +656,29 @@ agbrowse web-ai context-dry-run \
 
 ChatGPT:
 
-- `instant`, `fast`, `gpt-5.3`
-- `thinking`, `think`, `gpt-5.5-thinking`
-- `pro`, `gpt-5.5-pro`
+- `instant`, `fast`
+- `thinking`, `think`
+- `pro` (preferred stable alias)
+- Versioned aliases such as `gpt-5.3`, `gpt-5.5-thinking`, and `gpt-5.5-pro`
+  are legacy-compatible and do not pin the visible model family
 - `--effort` / `--reasoning-effort` for ChatGPT:
-  - Pro: `standard`, `extended`
+  - Pro: `standard`, `extended` for legacy compatibility; omit effort on a single-Pro UI
   - Thinking: `light`, `standard`, `extended`, `heavy`
+
+2026-07-10 ChatGPT Reasoning level UI note:
+
+- The composer picker may use `Reasoning level` / `추론 수준` and expose
+  `Instant`/`즉시`, `Medium`/`중간`, `High`/`높음`, `Extra High`/`매우 높음`,
+  and one `Pro` row.
+- The same picker can show a separate model-family submenu label such as
+  `GPT-5.6 Sol`. `--model pro` selects the reasoning level only; it does not
+  pin or change that family.
+- Prefer `--model pro` without `--effort`. If a legacy Pro effort is requested
+  while the UI exposes only one Pro row, agbrowse continues with Pro, emits a
+  warning, and records `effortStatus: unsupported-by-ui` plus the observed
+  `resolvedFamily`.
+- Explicit models fail before prompt submission when neither a checked picker
+  row nor the scoped composer pill can verify the requested level.
 
 2026-05-03 ChatGPT UI note:
 

--- a/test/fixtures/chatgpt-model/reasoning-level-en.html
+++ b/test/fixtures/chatgpt-model/reasoning-level-en.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <form>
+      <button class="__composer-pill" aria-haspopup="menu" aria-expanded="true">Pro</button>
+    </form>
+    <div role="menu" data-state="open">
+      <div data-testid="composer-intelligence-picker-content" role="group">
+        <div class="__menu-label">Reasoning level</div>
+        <div role="group">
+          <div role="menuitemradio" aria-checked="false"><span>Instant</span><span>5.5</span></div>
+          <div role="menuitemradio" aria-checked="false">Medium</div>
+          <div role="menuitemradio" aria-checked="false">High</div>
+          <div role="menuitemradio" aria-checked="false">Extra High</div>
+          <div role="menuitemradio" aria-checked="true" data-state="checked">Pro</div>
+        </div>
+        <div role="menuitem" aria-haspopup="menu" aria-expanded="false">GPT-5.6 Sol</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/fixtures/chatgpt-model/reasoning-level-ko.html
+++ b/test/fixtures/chatgpt-model/reasoning-level-ko.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="ko">
+  <body>
+    <form>
+      <button class="__composer-pill" aria-haspopup="menu" aria-expanded="true">Pro</button>
+    </form>
+    <div role="menu" data-state="open">
+      <div data-testid="composer-intelligence-picker-content" role="group">
+        <div class="__menu-label">추론 수준</div>
+        <div role="group">
+          <div role="menuitemradio" aria-checked="false"><span>즉시</span><span>5.5</span></div>
+          <div role="menuitemradio" aria-checked="false">중간</div>
+          <div role="menuitemradio" aria-checked="false">높음</div>
+          <div role="menuitemradio" aria-checked="false">매우 높음</div>
+          <div role="menuitemradio" aria-checked="true" data-state="checked">Pro</div>
+        </div>
+        <div role="menuitem" aria-haspopup="menu" aria-expanded="false">GPT-5.6 Sol</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/unit/web-ai-chatgpt-model.test.mjs
+++ b/test/unit/web-ai-chatgpt-model.test.mjs
@@ -5,6 +5,20 @@ import { join } from 'node:path';
 const modelSrc = readFileSync(join(process.cwd(), 'web-ai', 'chatgpt-model.mjs'), 'utf8');
 
 describe('web-ai ChatGPT model selector policy', () => {
+    it('keeps Korean and English fixtures for the current reasoning-level picker', () => {
+        const fixtureDir = join(process.cwd(), 'test', 'fixtures', 'chatgpt-model');
+        const ko = readFileSync(join(fixtureDir, 'reasoning-level-ko.html'), 'utf8');
+        const en = readFileSync(join(fixtureDir, 'reasoning-level-en.html'), 'utf8');
+
+        for (const fixture of [ko, en]) {
+            expect(fixture).toContain('composer-intelligence-picker-content');
+            expect(fixture).toContain('role="menuitemradio"');
+            expect(fixture).toContain('GPT-5.6 Sol');
+        }
+        expect(ko).toContain('추론 수준');
+        expect(en).toContain('Reasoning level');
+    });
+
     it('supports the observed Heavy/Pro effort UI', () => {
         expect(modelSrc).toContain('model-switcher-gpt-5-5-pro-thinking-effort');
         expect(modelSrc).toContain('model-switcher-gpt-5-5-thinking-thinking-effort');
@@ -105,6 +119,91 @@ describe('web-ai ChatGPT model selector policy', () => {
                 effort,
             });
         }
+    });
+
+    it.each(['ko', 'en'])('recognizes the current single-Pro reasoning picker (%s)', async language => {
+        const { selectChatGptModel } = await import('../../web-ai/chatgpt-model.mjs');
+        const page = createFakeModelPage({
+            model: 'pro',
+            initialModelMenuOpen: false,
+            roleButtonPill: true,
+            currentReasoningMenu: true,
+            currentReasoningLanguage: language,
+        });
+
+        await expect(selectChatGptModel(page, 'pro')).resolves.toMatchObject({
+            selected: 'pro',
+            warnings: [],
+            modelSelection: {
+                requestedModel: 'pro',
+                resolvedLabel: 'Pro',
+                normalizedModel: 'pro',
+                requestedEffort: null,
+                resolvedEffort: null,
+                effortStatus: 'not-requested',
+                resolvedFamily: 'GPT-5.6 Sol',
+                uiVariant: 'reasoning-level-with-family',
+                selectorSource: 'composer-intelligence-picker',
+                verified: true,
+            },
+        });
+    });
+
+    it('keeps legacy Pro effort as a warning-only no-op on the single-Pro UI', async () => {
+        const { selectChatGptModel } = await import('../../web-ai/chatgpt-model.mjs');
+        const page = createFakeModelPage({
+            model: 'pro',
+            initialModelMenuOpen: false,
+            roleButtonPill: true,
+            currentReasoningMenu: true,
+        });
+
+        await expect(selectChatGptModel(page, 'pro', { effort: 'extended' })).resolves.toMatchObject({
+            selected: 'pro',
+            effort: null,
+            requestedEffort: 'extended',
+            warnings: [expect.stringContaining('single Pro UI exposes no separate Pro effort control')],
+            modelSelection: {
+                requestedEffort: 'extended',
+                resolvedEffort: null,
+                effortStatus: 'unsupported-by-ui',
+                resolvedFamily: 'GPT-5.6 Sol',
+                verified: true,
+            },
+        });
+    });
+
+    it('returns ok for current Pro and warn for legacy Pro effort capability probes', async () => {
+        const { chatGptModelCapabilityProbe } = await import('../../web-ai/chatgpt-model.mjs');
+        const plainPage = createFakeModelPage({ model: 'pro', currentReasoningMenu: true });
+        const effortPage = createFakeModelPage({ model: 'pro', currentReasoningMenu: true });
+
+        await expect(chatGptModelCapabilityProbe(plainPage, 'pro')).resolves.toMatchObject({
+            state: 'ok',
+            evidence: {
+                effortStatus: 'not-requested',
+                resolvedFamily: 'GPT-5.6 Sol',
+                uiVariant: 'reasoning-level-with-family',
+            },
+        });
+        await expect(chatGptModelCapabilityProbe(effortPage, 'pro', { effort: 'extended' })).resolves.toMatchObject({
+            state: 'warn',
+            evidence: {
+                effortStatus: 'unsupported-by-ui',
+                resolvedFamily: 'GPT-5.6 Sol',
+            },
+            next: 'send',
+        });
+    });
+
+    it('warns that versioned aliases do not pin the ChatGPT model family', async () => {
+        const { selectChatGptModel } = await import('../../web-ai/chatgpt-model.mjs');
+        const page = createFakeModelPage({ model: 'pro', currentReasoningMenu: true });
+
+        await expect(selectChatGptModel(page, 'gpt-5.5-pro')).resolves.toMatchObject({
+            selected: 'pro',
+            warnings: [expect.stringContaining('does not pin the ChatGPT model family')],
+        });
     });
 
     it('selects every supported reasoning effort when ChatGPT puts the model name before the effort label', async () => {
@@ -640,7 +739,7 @@ describe('web-ai ChatGPT model selector policy', () => {
         });
     });
 
-    it('falls back to the current ChatGPT model when the model picker disappears and no effort is requested', async () => {
+    it('fails closed when an explicit ChatGPT model cannot be verified', async () => {
         const { selectChatGptModel } = await import('../../web-ai/chatgpt-model.mjs');
         const clock = useAdvancingClock();
         try {
@@ -650,21 +749,16 @@ describe('web-ai ChatGPT model selector policy', () => {
                 advanceClock: clock.advance,
             });
 
-            const result = await selectChatGptModel(page, 'thinking');
-
-        expect(result).toMatchObject({
-            requested: 'thinking',
-            selected: null,
-            alreadySelected: true,
-            warnings: [expect.stringContaining('requested thinking was not enforced')],
-        });
-        expect(result.usedFallbacks).toContain('model-selector-unavailable-current-model');
+            await expect(selectChatGptModel(page, 'thinking')).rejects.toMatchObject({
+                errorCode: 'provider.model-mismatch',
+                stage: 'provider-select-mode',
+            });
         } finally {
             clock.restore();
         }
     });
 
-    it('keeps sending when the model picker disappears with reasoning effort and reports the unenforced effort', async () => {
+    it('fails closed when an explicit model and effort cannot be verified', async () => {
         const { selectChatGptModel } = await import('../../web-ai/chatgpt-model.mjs');
         const clock = useAdvancingClock();
         try {
@@ -674,16 +768,10 @@ describe('web-ai ChatGPT model selector policy', () => {
                 advanceClock: clock.advance,
             });
 
-            const result = await selectChatGptModel(page, 'thinking', { effort: 'standard' });
-
-            expect(result).toMatchObject({
-                requested: 'thinking',
-                selected: null,
-                effort: null,
-                requestedEffort: 'standard',
-                warnings: [expect.stringContaining('requested effort standard was not enforced')],
+            await expect(selectChatGptModel(page, 'thinking', { effort: 'standard' })).rejects.toMatchObject({
+                errorCode: 'provider.model-mismatch',
+                stage: 'provider-select-mode',
             });
-            expect(result.usedFallbacks).toContain('model-selector-unavailable-current-model');
         } finally {
             clock.restore();
         }
@@ -790,6 +878,9 @@ function createFakeModelPage({
     modelPickerUnavailable = false,
     simplifiedIntelligenceMenu = false,
     simplifiedProExtendedOnly = false,
+    currentReasoningMenu = false,
+    currentReasoningLanguage = 'ko',
+    currentFamily = 'GPT-5.6 Sol',
     advanceClock = null,
 } = {}) {
     const missingModelTestIdSet = new Set(missingModelTestIds);
@@ -855,7 +946,46 @@ function createFakeModelPage({
             onClick: () => setSimplifiedSelection('pro', 'extended'),
         }),
     ];
-    const modelRows = simplifiedIntelligenceMenu ? simplifiedRows : legacyModelRows;
+    const currentLabels = currentReasoningLanguage === 'en'
+        ? { header: 'Reasoning level', instant: 'Instant\n5.5', standard: 'Medium', extended: 'High', heavy: 'Extra High', pro: 'Pro' }
+        : { header: '추론 수준', instant: '즉시\n5.5', standard: '중간', extended: '높음', heavy: '매우 높음', pro: 'Pro' };
+    const currentReasoningRows = [
+        createElement({
+            text: currentLabels.instant,
+            get checked() { return state.currentModel === 'instant'; },
+            onClick: () => setCurrentReasoningSelection('instant', null),
+        }),
+        createElement({
+            text: currentLabels.standard,
+            get checked() { return state.currentModel === 'thinking' && state.selectedEffort === 'standard'; },
+            onClick: () => setCurrentReasoningSelection('thinking', 'standard'),
+        }),
+        createElement({
+            text: currentLabels.extended,
+            get checked() { return state.currentModel === 'thinking' && state.selectedEffort === 'extended'; },
+            onClick: () => setCurrentReasoningSelection('thinking', 'extended'),
+        }),
+        createElement({
+            text: currentLabels.heavy,
+            get checked() { return state.currentModel === 'thinking' && state.selectedEffort === 'heavy'; },
+            onClick: () => setCurrentReasoningSelection('thinking', 'heavy'),
+        }),
+        createElement({
+            text: currentLabels.pro,
+            get checked() { return state.currentModel === 'pro'; },
+            onClick: () => setCurrentReasoningSelection('pro', null),
+        }),
+    ];
+    const familyTrigger = createElement({ text: currentFamily });
+    const currentPicker = createElement({
+        text: () => `${currentLabels.header}\n${currentReasoningRows.map(row => row.text).join('\n')}\n${currentFamily}`,
+        testId: 'composer-intelligence-picker-content',
+    });
+    const modelRows = currentReasoningMenu
+        ? currentReasoningRows
+        : simplifiedIntelligenceMenu
+            ? simplifiedRows
+            : legacyModelRows;
     const exactTrigger = createElement({
         text: exactEffortTriggerText,
         testId: `model-switcher-gpt-5-5-${exactEffortTriggerModel}-thinking-effort`,
@@ -879,7 +1009,9 @@ function createFakeModelPage({
     const modelPill = createElement({
         text: () => state.selectedEffort
             ? `${activePillTexts?.[state.selectedEffort] || effortTexts[state.selectedEffort] || currentEffortTexts()[state.selectedEffort] || state.currentModel}`
-            : state.currentModel,
+            : currentReasoningMenu
+                ? currentReasoningPillLabel()
+                : state.currentModel,
         onClick: () => { state.modelMenuOpen = true; },
     });
     const splitModelPill = createElement({
@@ -938,6 +1070,20 @@ function createFakeModelPage({
         state.modelMenuOpen = false;
     }
 
+    function setCurrentReasoningSelection(nextModel, nextEffort) {
+        state.currentModel = nextModel;
+        state.selectedEffort = nextEffort;
+        state.modelMenuOpen = false;
+    }
+
+    function currentReasoningPillLabel() {
+        if (state.currentModel === 'instant') return currentReasoningLanguage === 'en' ? 'Instant' : '즉시';
+        if (state.currentModel === 'pro') return 'Pro';
+        if (state.selectedEffort === 'extended') return currentLabels.extended;
+        if (state.selectedEffort === 'heavy') return currentLabels.heavy;
+        return currentLabels.standard;
+    }
+
     function currentEffortTexts() {
         if (state.effortMenuSource === 'generic' && genericEffortTexts) return genericEffortTexts;
         return effortTexts;
@@ -962,10 +1108,23 @@ function createFakeModelPage({
 
     function selectElements(selector) {
         if (modelPickerUnavailable) return [];
+        if (selector === '[data-testid="composer-intelligence-picker-content"]') {
+            return currentReasoningMenu && state.modelMenuOpen ? [currentPicker] : [];
+        }
+        if (selector.includes('[data-testid="composer-intelligence-picker-content"]') && selector.includes('[role="menuitemradio"]')) {
+            if (!currentReasoningMenu || !state.modelMenuOpen) return [];
+            return selector.includes('aria-checked="true"') || selector.includes('data-state="checked"')
+                ? currentReasoningRows.filter(row => row.checked)
+                : currentReasoningRows;
+        }
+        if (selector === '[data-testid="composer-intelligence-picker-content"] [role="menuitem"][aria-haspopup="menu"]') {
+            return currentReasoningMenu && state.modelMenuOpen ? [familyTrigger] : [];
+        }
         if (selector === 'button, [role="button"], [role="menuitem"]') return state.modelMenuOpen && !state.effortMenuOpen && state.genericEffortTrigger && genericTriggerMode === 'text' ? [...composerPills(), genericTrigger] : composerPills();
         if (selector.includes('__composer-pill')) return roleButtonPill ? composerPills() : [];
         if (selector === 'button') return roleButtonPill ? [] : [dropdownButton, ...composerPills(), closedHeroPill].filter(element => element.visible && (element !== closedHeroPill || closedHeroEffortPill));
         if (selector === '[role="menu"]') {
+            if (currentReasoningMenu && state.modelMenuOpen) return [currentPicker];
             if (simplifiedIntelligenceMenu && state.modelMenuOpen) return [createElement({ text: `Intelligence\n${simplifiedRows.map(row => row.text).join('\n')}\nGPT-5.5` })];
             return state.effortMenuOpen ? [createElement({ text: Object.values(currentEffortTexts()).join('\n') })] : [];
         }
@@ -1041,9 +1200,9 @@ describe('selectChatGptModel hardening (32.2 source contract)', () => {
         expect(src).toContain('MODEL_PILL_SETTLE_MS = 8_000');
     });
 
-    it('bounds model-option selection with retries and surfaces an unverified warning', () => {
+    it('bounds model-option selection with retries and fails closed when verification stays mismatched', () => {
         expect(src).toContain('MODEL_SELECT_MAX_ATTEMPTS = 3');
         expect(src).toMatch(/while \(currentModel !== requested && attempt < MODEL_SELECT_MAX_ATTEMPTS\)/);
-        expect(src).toContain("warnings.push('model-selection-unverified')");
+        expect(src).toContain('ChatGPT model verification failed');
     });
 });

--- a/test/unit/web-ai-sessions-command.test.mjs
+++ b/test/unit/web-ai-sessions-command.test.mjs
@@ -148,6 +148,12 @@ describe('web-ai sessions list / show / prune via runSessionsCommand', () => {
                     requestedModel: 'pro',
                     resolvedLabel: 'GPT-5.5 Pro',
                     normalizedModel: 'pro',
+                    requestedEffort: 'extended',
+                    resolvedEffort: null,
+                    effortStatus: 'unsupported-by-ui',
+                    resolvedFamily: 'GPT-5.6 Sol',
+                    uiVariant: 'reasoning-level-with-family',
+                    selectorSource: 'composer-intelligence-picker',
                     strategy: 'select',
                     status: 'switched',
                     verified: true,
@@ -169,8 +175,40 @@ describe('web-ai sessions list / show / prune via runSessionsCommand', () => {
             const output = logs.join('\n');
             expect(output).toContain('Browser evidence:');
             expect(output).toContain('model requested=pro; resolved=GPT-5.5 Pro; status=switched; strategy=select; verified=yes');
+            expect(output).toContain('effort requested=extended; resolved=(none); status=unsupported-by-ui');
+            expect(output).toContain('picker family=GPT-5.6 Sol; ui=reasoning-level-with-family; selector=composer-intelligence-picker');
             expect(output).toContain('warning browser-pro-fast-large-run: Large browser Pro run completed quickly.');
             expect(output).not.toContain('legacy warning string');
+        } finally {
+            console.log = originalLog;
+        }
+    });
+
+    it('human show remains compatible with legacy model selection evidence', async () => {
+        const logs = [];
+        const originalLog = console.log;
+        console.log = (line = '') => logs.push(String(line));
+        try {
+            const { runWebAiCli } = await import('../../web-ai/cli.mjs');
+            const { createSession } = await import('../../web-ai/session.mjs');
+            const { patchSession } = await import('../../web-ai/session-store.mjs');
+            const s = createSession({ vendor: 'chatgpt', prompt: 'legacy', attachmentPolicy: 'inline-only' });
+            patchSession(s.sessionId, {
+                modelSelection: {
+                    requestedModel: 'pro',
+                    resolvedLabel: 'Pro Extended',
+                    strategy: 'select',
+                    status: 'already-selected',
+                    verified: true,
+                },
+            });
+
+            await runWebAiCli(['sessions', 'show', s.sessionId]);
+
+            const output = logs.join('\n');
+            expect(output).toContain('model requested=pro; resolved=Pro Extended');
+            expect(output).not.toContain('effort requested=');
+            expect(output).not.toContain('picker family=');
         } finally {
             console.log = originalLog;
         }

--- a/web-ai/chatgpt-model.mjs
+++ b/web-ai/chatgpt-model.mjs
@@ -14,6 +14,12 @@ import { WebAiError } from './errors.mjs';
  * @property {string|null} requestedModel
  * @property {string|null} resolvedLabel
  * @property {ModelChoice|null} normalizedModel
+ * @property {EffortChoice|null} requestedEffort
+ * @property {EffortChoice|null} resolvedEffort
+ * @property {'not-requested'|'enforced'|'unsupported-by-ui'|'unverified'} effortStatus
+ * @property {string|null} resolvedFamily
+ * @property {'reasoning-level-with-family'|'simplified-intelligence'|'legacy'|'unknown'} uiVariant
+ * @property {string|null} selectorSource
  * @property {'select'} strategy
  * @property {ModelSelectionEvidenceStatus} status
  * @property {boolean} verified
@@ -35,6 +41,9 @@ const CHATGPT_COMPOSER_MODEL_PILL_SELECTORS = [
 ];
 
 const CHATGPT_MODEL_MENU_ITEM_SELECTOR = '[data-testid^="model-switcher-gpt-"]';
+const CHATGPT_INTELLIGENCE_PICKER_SELECTOR = '[data-testid="composer-intelligence-picker-content"]';
+const CHATGPT_REASONING_LEVEL_HEADER_PATTERN = /\b(?:Reasoning level|Intelligence)\b|추론 수준|지능/i;
+const CHATGPT_MODEL_FAMILY_PATTERN = /^GPT[-\s]?\d+(?:\.\d+)+(?:\s+[\p{L}\p{N}._-]+)*$/iu;
 const CHATGPT_MODEL_TEXT_BUTTON_PATTERN = /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b|즉시|중간|높음|매우 높음|Pro 확장|프로 확장)/i;
 const CHATGPT_OBSERVED_PRO_PILL_LABELS = ['Standard Pro', 'Extended Pro'];
 const CHATGPT_EFFORT_TRIGGER_SELECTORS = [
@@ -93,9 +102,9 @@ const CHATGPT_SIMPLIFIED_INTELLIGENCE_OPTIONS = {
         },
     },
     pro: {
-        defaultLabels: ['Pro Extended', 'Pro 확장', '프로 확장'],
+        defaultLabels: ['Pro', 'Pro Extended', 'Pro 확장', '프로 확장'],
         efforts: {
-            standard: ['Pro Extended', 'Pro 확장', '프로 확장'],
+            standard: ['Pro Standard', 'Pro Extended', 'Pro 확장', '프로 확장'],
             extended: ['Pro Extended', 'Pro 확장', '프로 확장'],
         },
     },
@@ -137,6 +146,11 @@ export function normalizeChatGptModelChoice(model) {
     const key = String(model || '').trim().toLowerCase();
     if (!key) return null;
     return MODEL_ALIASES[key] || null;
+}
+
+/** @param {unknown} model */
+function isVersionedChatGptAlias(model) {
+    return /^gpt[-\s]?\d+(?:[.-]\d+)+(?:[-\s](?:thinking|pro))?$/i.test(String(model || '').trim());
 }
 
 /**
@@ -221,25 +235,37 @@ export async function selectChatGptModel(page, model, options = {}) {
     const usedFallbacks = [];
     /** @type {string[]} */
     const warnings = [];
+    if (isVersionedChatGptAlias(model)) {
+        warnings.push(`legacy versioned model alias ${model} does not pin the ChatGPT model family; prefer ${requested}`);
+    }
     try {
         await openModelMenu(page, usedFallbacks);
     } catch (err) {
         if (!isSelectionUnavailable(err)) throw err;
-        const warning = buildModelSelectionWarning(requested, requestedEffort, err);
+        const pillEvidence = await readCheckedModelEvidence(page, requested || null);
+        if (!requested || pillEvidence?.choice !== requested) throw err;
+        const effortStatus = requestedEffort ? 'unverified' : 'not-requested';
+        if (requestedEffort) warnings.push(`reasoning effort ${requestedEffort} was not enforced: model picker unavailable`);
         return {
-            requested: requested || null,
-            selected: null,
+            requested,
+            selected: requested,
             alreadySelected: true,
             effort: null,
             requestedEffort: requestedEffort || null,
-            usedFallbacks: [...usedFallbacks, 'model-selector-unavailable-current-model'],
-            warnings: [warning],
+            usedFallbacks: [...usedFallbacks, 'model-selector-unavailable-verified-pill'],
+            warnings,
             modelSelection: createModelSelectionEvidence({
-                requestedModel: requested || String(model || '') || null,
-                resolvedLabel: null,
-                normalizedModel: null,
-                status: 'unavailable',
-                verified: false,
+                requestedModel: requested,
+                resolvedLabel: pillEvidence.label,
+                normalizedModel: requested,
+                requestedEffort: requestedEffort || null,
+                resolvedEffort: null,
+                effortStatus,
+                resolvedFamily: null,
+                uiVariant: 'unknown',
+                selectorSource: pillEvidence.selectorSource,
+                status: 'already-selected',
+                verified: true,
             }),
         };
     }
@@ -251,6 +277,7 @@ export async function selectChatGptModel(page, model, options = {}) {
         await closeModelMenu(page);
         throw new WebAiError({ errorCode: 'provider.model-mismatch', stage: 'provider-select-mode', vendor: 'chatgpt', retryHint: 'model-fallback', message: 'ChatGPT model must be selected before setting reasoning effort', evidence: { effort: requestedEffort } });
     }
+    let pickerContext = await readModelPickerContext(page);
     if (requested && currentModel !== requested) {
         // Bounded retry: ChatGPT occasionally drops the first option click (menu
         // re-render race), leaving the model unchanged. Re-click and re-verify up
@@ -265,12 +292,21 @@ export async function selectChatGptModel(page, model, options = {}) {
             await openModelMenu(page, usedFallbacks);
             currentEvidence = await readCheckedModelEvidence(page, requested);
             currentModel = currentEvidence?.choice || null;
+            pickerContext = await readModelPickerContext(page);
             modelChanged = true;
         }
         // Explicit model requested but unverified after retries — surface it.
         // Effort selection (below) still fails closed on mismatch.
-        if (currentModel !== requested && !warnings.includes('model-selection-unverified')) {
-            warnings.push('model-selection-unverified');
+        if (currentModel !== requested) {
+            await closeModelMenu(page);
+            throw new WebAiError({
+                errorCode: 'provider.model-mismatch',
+                stage: 'provider-select-mode',
+                vendor: 'chatgpt',
+                retryHint: 'model-fallback',
+                message: `ChatGPT model verification failed: expected ${requested}, got ${currentModel || 'none'}`,
+                evidence: { requested, got: currentModel || null },
+            });
         }
     }
     /** @type {{ requested: string, selected: string|null, changed: boolean } | null} */
@@ -289,7 +325,10 @@ export async function selectChatGptModel(page, model, options = {}) {
             } catch (err) {
                 if (!isSelectionUnavailable(err)) throw err;
                 usedFallbacks.push('reasoning-effort-unavailable-current-effort');
-                warnings.push(`reasoning effort ${requestedEffort} was not enforced: ${errorMessage(err)}`);
+                const compatibilityNote = targetModel === 'pro' && pickerContext.uiVariant === 'reasoning-level-with-family'
+                    ? 'single Pro UI exposes no separate Pro effort control'
+                    : errorMessage(err);
+                warnings.push(`reasoning effort ${requestedEffort} was not enforced: ${compatibilityNote}`);
                 await closeModelMenu(page);
             }
         }
@@ -298,10 +337,23 @@ export async function selectChatGptModel(page, model, options = {}) {
     const after = afterEvidence?.choice || null;
     await closeModelMenu(page);
     if (after !== targetModel) {
-        usedFallbacks.push('model-verification-unavailable-current-model');
-        warnings.push(`model ${targetModel} was not verified; current detected model is ${after || 'unknown'}`);
+        throw new WebAiError({
+            errorCode: 'provider.model-mismatch',
+            stage: 'provider-select-mode',
+            vendor: 'chatgpt',
+            retryHint: 'model-fallback',
+            message: `ChatGPT model verification failed: expected ${targetModel}, got ${after || 'none'}`,
+            evidence: { requested: targetModel, got: after || null },
+        });
     }
     const verified = after === targetModel;
+    const effortStatus = !requestedEffort
+        ? 'not-requested'
+        : selectedEffort?.selected
+            ? 'enforced'
+            : targetModel === 'pro' && pickerContext.uiVariant === 'reasoning-level-with-family'
+                ? 'unsupported-by-ui'
+                : 'unverified';
     return {
         requested: requested || targetModel,
         selected: after,
@@ -314,6 +366,12 @@ export async function selectChatGptModel(page, model, options = {}) {
             requestedModel: requested || targetModel || null,
             resolvedLabel: afterEvidence?.label || after || null,
             normalizedModel: after,
+            requestedEffort: requestedEffort || null,
+            resolvedEffort: /** @type {EffortChoice | null} */ (selectedEffort?.selected || null),
+            effortStatus,
+            resolvedFamily: pickerContext.resolvedFamily,
+            uiVariant: pickerContext.uiVariant,
+            selectorSource: afterEvidence?.selectorSource || pickerContext.selectorSource,
             status: verified ? (modelChanged ? 'switched' : 'already-selected') : (modelChanged ? 'switched-best-effort' : 'unavailable'),
             verified,
         }),
@@ -325,6 +383,12 @@ export async function selectChatGptModel(page, model, options = {}) {
  *   requestedModel: string|null,
  *   resolvedLabel: string|null,
  *   normalizedModel: ModelChoice|null,
+ *   requestedEffort: EffortChoice|null,
+ *   resolvedEffort: EffortChoice|null,
+ *   effortStatus: 'not-requested'|'enforced'|'unsupported-by-ui'|'unverified',
+ *   resolvedFamily: string|null,
+ *   uiVariant: 'reasoning-level-with-family'|'simplified-intelligence'|'legacy'|'unknown',
+ *   selectorSource: string|null,
  *   status: ModelSelectionEvidenceStatus,
  *   verified: boolean,
  * }} input
@@ -335,6 +399,12 @@ function createModelSelectionEvidence(input) {
         requestedModel: input.requestedModel,
         resolvedLabel: input.resolvedLabel,
         normalizedModel: input.normalizedModel,
+        requestedEffort: input.requestedEffort,
+        resolvedEffort: input.resolvedEffort,
+        effortStatus: input.effortStatus,
+        resolvedFamily: input.resolvedFamily,
+        uiVariant: input.uiVariant,
+        selectorSource: input.selectorSource,
         strategy: 'select',
         status: input.status,
         verified: input.verified,
@@ -352,22 +422,6 @@ function isSelectionUnavailable(err) {
     return error instanceof WebAiError
         && error.errorCode === 'provider.model-mismatch'
         && error.stage === 'provider-select-mode';
-}
-
-/**
- * @param {ModelChoice | null} requested
- * @param {EffortChoice | null} requestedEffort
- * @param {unknown} err
- * @returns {string}
- */
-function buildModelSelectionWarning(requested, requestedEffort, err) {
-    const modelText = requested
-        ? `requested ${requested} was not enforced`
-        : 'model selector unavailable';
-    const effortText = requestedEffort
-        ? `; requested effort ${requestedEffort} was not enforced`
-        : '';
-    return `${modelText}${effortText}, continuing with current ChatGPT model: ${errorMessage(err)}`;
 }
 
 /**
@@ -482,6 +536,8 @@ async function findModelTextButton(page) {
  */
 async function findModelOption(page, choice) {
     const option = CHATGPT_MODEL_OPTIONS[choice];
+    const currentReasoningOption = await findCurrentReasoningOption(page, choice);
+    if (currentReasoningOption) return currentReasoningOption;
     await openSimplifiedIntelligenceSubmenu(page).catch(() => undefined);
     for (const testId of option.testIds) {
         const loc = page.locator(`[role="menuitemradio"][data-testid="${testId}"], [data-testid="${testId}"]`).first();
@@ -502,6 +558,26 @@ async function findModelOption(page, choice) {
     const simplified = await findOptionByExactLabels(page, simplifiedDefaultLabels(choice));
     if (simplified && await isSimplifiedIntelligenceMenuOpen(page, choice, null)) return simplified;
     if (simplified && await isModelOptionCandidate(simplified, choice)) return simplified;
+    return null;
+}
+
+/**
+ * Scope current reasoning-level rows to the composer picker. The page can also
+ * contain unrelated "Pro" controls (for example the account button), so broad
+ * text locators are intentionally avoided on this UI variant.
+ * @param {Page} page
+ * @param {ModelChoice} choice
+ * @returns {Promise<Locator|null>}
+ */
+async function findCurrentReasoningOption(page, choice) {
+    const rows = await page.locator(`${CHATGPT_INTELLIGENCE_PICKER_SELECTOR} [role="menuitemradio"]`)
+        .all()
+        .catch(() => /** @type {Locator[]} */ ([]));
+    for (const row of rows) {
+        if (!(await row.isVisible().catch(() => false))) continue;
+        const text = (await row.innerText({ timeout: 500 }).catch(() => '')).trim();
+        if (modelChoiceFromText(text) === choice) return row;
+    }
     return null;
 }
 
@@ -834,13 +910,22 @@ async function readCheckedModel(page, expectedModel = null) {
  * @returns {Promise<{ choice: ModelChoice, label: string } | null>}
  */
 async function readCheckedModelEvidence(page, expectedModel = null) {
+    const currentRows = await page.locator([
+        `${CHATGPT_INTELLIGENCE_PICKER_SELECTOR} [role="menuitemradio"][aria-checked="true"]`,
+        `${CHATGPT_INTELLIGENCE_PICKER_SELECTOR} [role="menuitemradio"][data-state="checked"]`,
+    ].join(', ')).all().catch(() => /** @type {Locator[]} */ ([]));
+    for (const row of currentRows) {
+        const text = (await row.innerText({ timeout: 500 }).catch(() => '')).trim();
+        const choice = modelChoiceFromText(text);
+        if (choice) return { choice, label: text || String(choice), selectorSource: 'composer-intelligence-picker' };
+    }
     for (const [choice, option] of Object.entries(CHATGPT_MODEL_OPTIONS)) {
         for (const testId of option.testIds) {
             const row = page.locator(`[role="menuitemradio"][data-testid="${testId}"][aria-checked="true"], [data-testid="${testId}"][aria-checked="true"]`).first();
             const checked = await row.isVisible().catch(() => false);
             if (checked) {
                 const label = (await row.innerText({ timeout: 500 }).catch(() => '')).trim();
-                return { choice: /** @type {ModelChoice} */ (choice), label: label || String(choice) };
+                return { choice: /** @type {ModelChoice} */ (choice), label: label || String(choice), selectorSource: 'legacy-model-testid' };
             }
         }
     }
@@ -849,11 +934,51 @@ async function readCheckedModelEvidence(page, expectedModel = null) {
         const text = (await row.innerText({ timeout: 500 }).catch(() => '')).trim();
         if (isStandaloneEffortLabel(text)) continue;
         const choice = modelChoiceFromText(text);
-        if (choice) return { choice, label: text || String(choice) };
+        if (choice) return { choice, label: text || String(choice), selectorSource: 'checked-menuitemradio' };
     }
     const active = await readActiveModelPill(page, { allowStandaloneHeavy: expectedModel === 'pro' });
     const choice = modelChoiceFromText(active);
-    return choice ? { choice, label: active || String(choice) } : null;
+    return choice ? { choice, label: active || String(choice), selectorSource: 'composer-model-pill' } : null;
+}
+
+/**
+ * @param {Page} page
+ * @returns {Promise<{
+ *   resolvedFamily: string|null,
+ *   uiVariant: 'reasoning-level-with-family'|'simplified-intelligence'|'legacy'|'unknown',
+ *   selectorSource: string|null,
+ * }>}
+ */
+async function readModelPickerContext(page) {
+    const picker = page.locator(CHATGPT_INTELLIGENCE_PICKER_SELECTOR).first();
+    if (await picker.isVisible().catch(() => false)) {
+        const text = (await picker.innerText({ timeout: 500 }).catch(() => '')).trim();
+        const familyRows = await page.locator(`${CHATGPT_INTELLIGENCE_PICKER_SELECTOR} [role="menuitem"][aria-haspopup="menu"]`)
+            .all()
+            .catch(() => /** @type {Locator[]} */ ([]));
+        let resolvedFamily = null;
+        for (const row of familyRows) {
+            const label = (await row.innerText({ timeout: 500 }).catch(() => '')).trim();
+            if (CHATGPT_MODEL_FAMILY_PATTERN.test(label)) {
+                resolvedFamily = label;
+                break;
+            }
+        }
+        return {
+            resolvedFamily,
+            uiVariant: /\bReasoning level\b|추론 수준/i.test(text)
+                ? 'reasoning-level-with-family'
+                : 'simplified-intelligence',
+            selectorSource: 'composer-intelligence-picker',
+        };
+    }
+    if (await isSimplifiedIntelligenceMenuOpen(page, null, null)) {
+        return { resolvedFamily: null, uiVariant: 'simplified-intelligence', selectorSource: 'role-menu' };
+    }
+    if (await isModelMenuOpenLegacy(page)) {
+        return { resolvedFamily: null, uiVariant: 'legacy', selectorSource: 'legacy-model-testid' };
+    }
+    return { resolvedFamily: null, uiVariant: 'unknown', selectorSource: null };
 }
 
 /**
@@ -926,7 +1051,27 @@ async function readActiveEffortPill(page) {
  * @returns {Promise<boolean>}
  */
 async function isModelMenuOpen(page) {
-    const legacyOpen = await page.locator(CHATGPT_MODEL_MENU_ITEM_SELECTOR)
+    const picker = page.locator(CHATGPT_INTELLIGENCE_PICKER_SELECTOR).first();
+    if (await picker.isVisible().catch(() => false)) {
+        const text = (await picker.innerText({ timeout: 500 }).catch(() => '')).trim();
+        const rowsVisible = await page.locator(`${CHATGPT_INTELLIGENCE_PICKER_SELECTOR} [role="menuitemradio"]`)
+            .first()
+            .isVisible()
+            .catch(() => false);
+        if (rowsVisible && CHATGPT_REASONING_LEVEL_HEADER_PATTERN.test(text)) return true;
+    }
+    const legacyOpen = await isModelMenuOpenLegacy(page);
+    if (legacyOpen || await isSimplifiedIntelligenceMenuOpen(page, null, null)) return true;
+    return page.locator('[role="menuitem"], [role="button"], button')
+        .filter({ hasText: /^GPT[-\s]?5\.5$/i })
+        .first()
+        .isVisible()
+        .catch(() => false);
+}
+
+/** @param {Page} page */
+async function isModelMenuOpenLegacy(page) {
+    return page.locator(CHATGPT_MODEL_MENU_ITEM_SELECTOR)
         .filter({ hasText: CHATGPT_MODEL_TEXT_BUTTON_PATTERN })
         .evaluateAll((items) => items.some(item => {
             const text = (/** @type {HTMLElement} */ (item).innerText || item.textContent || '').trim();
@@ -935,12 +1080,6 @@ async function isModelMenuOpen(page) {
             if (testId.includes('effort') && /^(Light|Standard|Extended|Heavy|Standard Pro|Extended Pro)$/i.test(text)) return false;
             return /^(ChatGPT|GPT[-\s]?\d|((Light|Standard|Extended|Heavy)\s+)?(Instant|Fast|Thinking|Pro|Heavy)\b|Medium\b|High\b|Extra High\b|Pro Standard\b|Pro Extended\b|즉시|중간|높음|매우 높음|Pro 확장|프로 확장)/i.test(text);
         }))
-        .catch(() => false);
-    if (legacyOpen || await isSimplifiedIntelligenceMenuOpen(page, null, null)) return true;
-    return page.locator('[role="menuitem"], [role="button"], button')
-        .filter({ hasText: /^GPT[-\s]?5\.5$/i })
-        .first()
-        .isVisible()
         .catch(() => false);
 }
 
@@ -1008,7 +1147,7 @@ async function isSimplifiedIntelligenceMenuOpen(page, model, effort) {
     if (requiredLabels.length === 0) return false;
     return page.locator('[role="menu"]').evaluateAll((menus, labels) => menus.some(menu => {
         const text = /** @type {HTMLElement} */ (menu).innerText || menu.textContent || '';
-        if (!/\bIntelligence\b|지능/i.test(text)) return false;
+        if (!/\b(?:Reasoning level|Intelligence)\b|추론 수준|지능/i.test(text)) return false;
         return labels.some(label => menuTextHasExactLine(text, label));
     }), requiredLabels).catch(() => false);
 }
@@ -1137,6 +1276,7 @@ export async function chatGptModelCapabilityProbe(page, model, options = {}) {
         return { state: 'fail', evidence: { requested, menuOpenFailed: true, usedFallbacks }, next: 'model-fallback' };
     }
     const option = await findModelOption(page, requested).catch(() => null);
+    const pickerContext = await readModelPickerContext(page);
     /** @type {Locator | null} */
     let effortOption = null;
     if (option && requestedEffort) {
@@ -1154,7 +1294,27 @@ export async function chatGptModelCapabilityProbe(page, model, options = {}) {
     } catch {
         menuClosed = false;
     }
-    const selectable = Boolean(option) && (!requestedEffort || Boolean(effortOption));
-    const state = selectable ? (menuClosed ? 'ok' : 'warn') : 'fail';
-    return { state, evidence: { requested, effort: requestedEffort || null, menuClosed, usedFallbacks }, next: state === 'ok' ? 'send' : 'model-fallback' };
+    const compatibilityNoop = Boolean(option)
+        && requested === 'pro'
+        && Boolean(requestedEffort)
+        && !effortOption
+        && pickerContext.uiVariant === 'reasoning-level-with-family';
+    const selectable = Boolean(option) && (!requestedEffort || Boolean(effortOption) || compatibilityNoop);
+    const state = selectable
+        ? compatibilityNoop || !menuClosed ? 'warn' : 'ok'
+        : 'fail';
+    return {
+        state,
+        evidence: {
+            requested,
+            effort: requestedEffort || null,
+            effortStatus: compatibilityNoop ? 'unsupported-by-ui' : requestedEffort ? 'enforced' : 'not-requested',
+            resolvedFamily: pickerContext.resolvedFamily,
+            uiVariant: pickerContext.uiVariant,
+            selectorSource: pickerContext.selectorSource,
+            menuClosed,
+            usedFallbacks,
+        },
+        next: state === 'fail' ? 'model-fallback' : 'send',
+    };
 }

--- a/web-ai/cli-sessions.mjs
+++ b/web-ai/cli-sessions.mjs
@@ -282,6 +282,12 @@ function formatBrowserEvidenceLines(session) {
         const strategy = evidence.strategy ?? '(default)';
         const verified = evidence.verified ? 'yes' : 'no';
         lines.push(`model requested=${requested}; resolved=${resolved}; status=${evidence.status || 'unknown'}; strategy=${strategy}; verified=${verified}`);
+        if (evidence.requestedEffort || evidence.resolvedEffort || evidence.effortStatus) {
+            lines.push(`effort requested=${evidence.requestedEffort ?? '(none)'}; resolved=${evidence.resolvedEffort ?? '(none)'}; status=${evidence.effortStatus || 'unknown'}`);
+        }
+        if (evidence.resolvedFamily || evidence.uiVariant || evidence.selectorSource) {
+            lines.push(`picker family=${evidence.resolvedFamily ?? '(unavailable)'}; ui=${evidence.uiVariant || 'unknown'}; selector=${evidence.selectorSource || '(unknown)'}`);
+        }
     }
     for (const warning of session?.warnings || []) {
         if (!warning || typeof warning !== 'object' || !warning.code) continue;

--- a/web-ai/cli.mjs
+++ b/web-ai/cli.mjs
@@ -117,8 +117,9 @@ Provider:
                       ONLY touched when this flag is provided; otherwise the
                       currently-checked effort in the browser is left as-is.
                       Requires a model because legacy Pro/Thinking menus and the
-                      simplified Intelligence menu map efforts differently.
-                        Pro: standard, extended
+                      current reasoning-level picker map efforts differently.
+                        Pro: standard, extended (legacy compatibility; a
+                             single-Pro UI warns and continues without effort)
                         Thinking: light, standard, extended, heavy
   --reasoning-effort <alias>
                       Alias for --effort
@@ -357,7 +358,7 @@ Required:
 Recommended model:
   --model thinking      Use ChatGPT thinking mode for code work.
   --effort <alias>      thinking: light|standard|extended|heavy
-                        pro: standard|extended
+                        pro: standard|extended (legacy compatibility)
 
 Artifact options:
   --output-zip <path>   Save one generated zip to this path.


### PR DESCRIPTION
## Summary
- recognize the current Reasoning level / 추론 수준 picker through its scoped composer test id
- separate the checked Pro reasoning level from the visible GPT-5.6 Sol family evidence
- keep legacy Pro effort flags as warning-only no-ops when the UI exposes one Pro row
- extend persisted model-selection evidence and keep legacy session output compatible
- update CLI, README, bundled skill, and Korean/English fixtures

## Verification
- focused model, session, CLI, and contract tests: 83 passed
- full Vitest suite passed
- all 16 release gates passed
- live Pro capability probe: ok
- live legacy Pro effort probe: warn with effortStatus=unsupported-by-ui
- live send persisted verified=true, resolvedLabel=Pro, resolvedFamily=GPT-5.6 Sol