### PR TITLE
fix(web-ai): bound assistant DOM reads by the polling deadline

### DIFF
--- a/structure/str_func.md
+++ b/structure/str_func.md
@@ -16,7 +16,7 @@ aliases: [agbrowse source map, agbrowse str_func, agbrowse 파일 구조]
 
 ## 현재 구조 스냅샷
 
-마지막 측정: 2026-07-11.
+마지막 측정: 2026-07-27.
 
 | 경로 | 파일 수 | 라인 수 | 역할 |
 | --- | ---: | ---: | --- |
@@ -25,13 +25,13 @@ aliases: [agbrowse source map, agbrowse str_func, agbrowse 파일 구조]
 | `skills/search/` | 5 | 896 | standalone search skill doc (any CLI agent) |
 | `skills/vision-click/` | 4 | 1215 | screenshot to coordinate click helper |
 | `skills/web-ai/` | 3 | 872 | bundled agent workflow skill |
-| `web-ai/` | 113 | 27479 | provider automation, sessions, MCP, eval, policy, trace |
+| `web-ai/` | 113 | 27694 | provider automation, sessions, MCP, eval, policy, trace |
 | `web-ai/context-pack/` | 8 | 858 | file selection, token budget, context rendering |
 | `web-ai/eval/` | 5 | 553 | offline provider DOM fixture harness |
 | `web-ai/policy/` | 4 | 238 | mutation and content-boundary guardrails |
 | `web-ai/trace/` | 5 | 444 | trace ID, redaction, report, writer helpers |
 | `scripts/` | 10 | 1621 | eval runner, release scripts, named release gates, strict-baseline / module-graph / bin smoke checks |
-| `test/unit/` | 141 | 17677 | deterministic module tests |
+| `test/unit/` | 142 | 17835 | deterministic module tests |
 | `test/integration/` | 21 | 3167 | CLI, MCP, policy, provider fixture tests |
 | `test/e2e/` | 1 | 50 | browser smoke coverage |
 | `test/spec/` | 2 | 35 | high-level contract specs |
@@ -82,9 +82,9 @@ aliases: [agbrowse source map, agbrowse str_func, agbrowse 파일 구조]
 | `skills/browser/adaptive-fetch/browser-runtime.mjs` | 38 | browser page acquisition and cleanup |
 | `web-ai/cli.mjs` | 2010 | `web-ai` subcommand parser and command orchestration |
 | `web-ai/session-target-guard.mjs` | 151 | shared CDP session candidate selection, ambiguity errors, and target-mismatch recovery envelopes |
-| `web-ai/chatgpt.mjs` | 1110 | ChatGPT provider send/poll/query/status with streaming-safe recovery gates |
-| `web-ai/chatgpt-response-dom.mjs` | 74 | shared ChatGPT top-level assistant DOM extraction helpers |
-| `web-ai/chatgpt-response-observer.mjs` | 190 | ChatGPT observer wake signal and timeout recovery metadata |
+| `web-ai/chatgpt.mjs` | 1222 | ChatGPT provider send/poll/query/status with streaming-safe recovery gates |
+| `web-ai/chatgpt-response-dom.mjs` | 170 | shared ChatGPT top-level assistant DOM extraction helpers |
+| `web-ai/chatgpt-response-observer.mjs` | 197 | ChatGPT observer wake signal and timeout recovery metadata |
 | `web-ai/gemini-live.mjs` | 804 | Gemini provider send/poll/query/status |
 | `web-ai/grok-live.mjs` | 594 | Grok provider send/poll/query/status |
 | `web-ai/mcp-server.mjs` | 467 | stdio JSON-RPC MCP bridge |

--- a/test/unit/web-ai-assistant-read-deadline.test.mjs
+++ b/test/unit/web-ai-assistant-read-deadline.test.mjs
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+// Regression coverage for #88: the poll loop only re-checked its deadline at the
+// `while` boundary, and `readAssistantMessages()` awaited `page.evaluate()` with
+// no per-call bound. A never-resolving evaluate therefore suspended the command
+// past --timeout instead of returning a recoverable poll timeout.
+
+describe('bounded assistant DOM reads (#88)', () => {
+    it('withAssistantReadTimeout resolves the sentinel instead of hanging', async () => {
+        const { withAssistantReadTimeout, ASSISTANT_READ_TIMED_OUT } =
+            await import('../../web-ai/chatgpt-response-dom.mjs');
+
+        const neverResolves = new Promise(() => {});
+        const started = Date.now();
+        const result = await withAssistantReadTimeout(neverResolves, 50);
+
+        expect(result).toBe(ASSISTANT_READ_TIMED_OUT);
+        expect(Date.now() - started).toBeLessThan(2_000);
+    });
+
+    it('withAssistantReadTimeout returns the value when the read wins', async () => {
+        const { withAssistantReadTimeout } = await import('../../web-ai/chatgpt-response-dom.mjs');
+        await expect(withAssistantReadTimeout(Promise.resolve(['answer']), 5_000))
+            .resolves.toEqual(['answer']);
+    });
+
+    it('withAssistantReadTimeout treats a rejected read as timed out, never throws', async () => {
+        const { withAssistantReadTimeout, ASSISTANT_READ_TIMED_OUT } =
+            await import('../../web-ai/chatgpt-response-dom.mjs');
+        await expect(withAssistantReadTimeout(Promise.reject(new Error('detached')), 5_000))
+            .resolves.toBe(ASSISTANT_READ_TIMED_OUT);
+    });
+
+    it('resolveAssistantReadBudgetMs clamps to the remaining deadline', async () => {
+        const { resolveAssistantReadBudgetMs, ASSISTANT_READ_TIMEOUT_MS } =
+            await import('../../web-ai/chatgpt-response-dom.mjs');
+
+        expect(resolveAssistantReadBudgetMs(undefined)).toBe(ASSISTANT_READ_TIMEOUT_MS);
+        expect(resolveAssistantReadBudgetMs(500)).toBe(500);
+        expect(resolveAssistantReadBudgetMs(ASSISTANT_READ_TIMEOUT_MS + 60_000))
+            .toBe(ASSISTANT_READ_TIMEOUT_MS);
+        expect(resolveAssistantReadBudgetMs(0)).toBe(0);
+        expect(resolveAssistantReadBudgetMs(-5)).toBe(0);
+    });
+
+    it('pollWebAi returns a recoverable timeout when every assistant read stalls', async () => {
+        const { pollWebAi } = await import('../../web-ai/chatgpt.mjs');
+        const { createSession } = await import('../../web-ai/session.mjs');
+
+        const session = createSession(
+            { vendor: 'chatgpt', prompt: 'huge conversation', attachmentPolicy: 'inline-only' },
+            {
+                targetId: 'target-stalled-dom',
+                conversationUrl: 'https://chatgpt.com/c/stalled',
+                deadlineAt: new Date(Date.now() + 60_000).toISOString(),
+                envelopeSummary: { assistantCount: 3 },
+            },
+        );
+
+        let evaluateCalls = 0;
+        const page = {
+            url: () => 'https://chatgpt.com/c/stalled',
+            // Simulates the reported failure: assistant-message extraction never
+            // returns because the conversation is too large to serialize.
+            evaluate: async () => {
+                evaluateCalls += 1;
+                return new Promise(() => {});
+            },
+            waitForTimeout: async (ms) => new Promise(resolve => setTimeout(resolve, Math.min(Number(ms) || 0, 20))),
+            locator: () => ({
+                first: () => ({ isVisible: async () => false }),
+                all: async () => [],
+            }),
+            innerText: async () => '',
+        };
+
+        const started = Date.now();
+        const result = await pollWebAi({
+            getPage: async () => page,
+            getTargetId: async () => 'target-stalled-dom',
+        }, {
+            vendor: 'chatgpt',
+            session: session.sessionId,
+            timeout: 2,
+        });
+        const elapsedMs = Date.now() - started;
+
+        expect(result).toMatchObject({
+            ok: false,
+            vendor: 'chatgpt',
+            status: 'timeout',
+            sessionId: session.sessionId,
+            recoverable: true,
+            retryHint: 'poll-or-resume',
+        });
+        // The command must honor its own deadline rather than parking forever.
+        expect(elapsedMs).toBeLessThan(30_000);
+        expect(evaluateCalls).toBeGreaterThan(0);
+        // A stalled read is reported distinctly from "provider still generating".
+        expect(result.warnings.some(w => String(w).startsWith('assistant-dom-read-timeout:'))).toBe(true);
+    }, 40_000);
+});
+
+describe('post-baseline assistant extraction (#88)', () => {
+    it('serializes only turns at/after the baseline index', async () => {
+        const { readAssistantTextsAfterIndex } = await import('../../web-ai/chatgpt-response-dom.mjs');
+
+        const serialized = [];
+        const makeNode = (label) => ({
+            get innerText() {
+                serialized.push(label);
+                return label;
+            },
+            textContent: label,
+            contains: () => false,
+        });
+        const nodes = ['old-1', 'old-2', 'old-3', 'new-1'].map(makeNode);
+        const selectors = ['[data-message-author-role="assistant"]'];
+
+        const previous = globalThis.document;
+        globalThis.document = {
+            querySelectorAll: (selector) => (selector === selectors[0] ? nodes : []),
+        };
+        try {
+            const result = readAssistantTextsAfterIndex({ selectors, minIndex: 3 });
+            expect(result.total).toBe(4);
+            expect(result.texts).toEqual(['new-1']);
+            // Historical turns must not be re-serialized on every tick.
+            expect(serialized).toEqual(['new-1']);
+        } finally {
+            if (previous === undefined) delete globalThis.document;
+            else globalThis.document = previous;
+        }
+    });
+
+    it('reports the full turn count so baseline math stays correct', async () => {
+        const { readAssistantTextsAfterIndex } = await import('../../web-ai/chatgpt-response-dom.mjs');
+        const selectors = ['[data-message-author-role="assistant"]'];
+        const nodes = ['a', 'b'].map(text => ({ innerText: text, textContent: text, contains: () => false }));
+
+        const previous = globalThis.document;
+        globalThis.document = {
+            querySelectorAll: (selector) => (selector === selectors[0] ? nodes : []),
+        };
+        try {
+            expect(readAssistantTextsAfterIndex({ selectors, minIndex: 0 }))
+                .toEqual({ total: 2, texts: ['a', 'b'] });
+        } finally {
+            if (previous === undefined) delete globalThis.document;
+            else globalThis.document = previous;
+        }
+    });
+});

--- a/test/unit/web-ai-provider-session.test.mjs
+++ b/test/unit/web-ai-provider-session.test.mjs
@@ -404,19 +404,23 @@ function createCopyMarkdownDeferredChatGptPage(text) {
         textContent: 'Answer now',
         contains: () => false,
     };
-    let evaluateCount = 0;
+    let readCount = 0;
     let stopVisible = false;
     return {
         url: () => 'https://chatgpt.com/c/copy-streaming',
-        evaluate: async (fn, selectors) => {
-            evaluateCount += 1;
-            const currentNode = evaluateCount === 1 ? node : placeholderNode;
+        evaluate: async (fn, arg) => {
+            // Assistant reads pass either the selector array or { selectors,
+            // minIndex }; count only those so unrelated evaluate calls (stop
+            // button, finished-actions probes) do not advance the sequence.
+            const selectors = Array.isArray(arg) ? arg : arg?.selectors;
+            if (selectors) readCount += 1;
+            const currentNode = readCount <= 1 ? node : placeholderNode;
             const previous = globalThis.document;
             globalThis.document = {
-                querySelectorAll: (selector) => selector === selectors[0] ? [currentNode] : [],
+                querySelectorAll: (selector) => selectors && selector === selectors[0] ? [currentNode] : [],
             };
             try {
-                return fn(selectors);
+                return fn(arg);
             } finally {
                 if (previous === undefined) delete globalThis.document;
                 else globalThis.document = previous;

--- a/web-ai/chatgpt-response-dom.mjs
+++ b/web-ai/chatgpt-response-dom.mjs
@@ -1,5 +1,13 @@
 // @ts-check
 
+/**
+ * Per-read ceiling for a single assistant-DOM read. Playwright's
+ * `page.evaluate()` takes no timeout option, so a stalled or very slow
+ * evaluation (large conversation, blocked main thread) can otherwise park the
+ * poll loop past its own deadline (#88).
+ */
+export const ASSISTANT_READ_TIMEOUT_MS = 10_000;
+
 export const CHATGPT_ASSISTANT_SELECTORS = [
     '[data-message-author-role="assistant"]',
     '[data-turn="assistant"]',
@@ -10,6 +18,59 @@ export const CHATGPT_STOP_SELECTORS = [
     'button[data-testid="stop-button"]',
     'button[aria-label*="Stop" i]',
 ];
+
+/**
+ * Sentinel resolved when a bounded read exceeds its budget. Distinct from `[]`
+ * so callers can tell "no assistant turns yet" from "the read did not finish".
+ */
+export const ASSISTANT_READ_TIMED_OUT = Symbol('assistant-read-timed-out');
+
+/**
+ * Bound any assistant-DOM read by a deadline. Resolves the task's value, or
+ * ASSISTANT_READ_TIMED_OUT when the budget elapses first. The underlying task is
+ * never awaited further; its rejection is swallowed so an abandoned read cannot
+ * surface as an unhandled rejection.
+ * @template T
+ * @param {Promise<T>} task
+ * @param {number} timeoutMs
+ * @returns {Promise<T | typeof ASSISTANT_READ_TIMED_OUT>}
+ */
+export async function withAssistantReadTimeout(task, timeoutMs) {
+    const budget = Number(timeoutMs);
+    if (!Number.isFinite(budget) || budget <= 0) return ASSISTANT_READ_TIMED_OUT;
+    /** @type {ReturnType<typeof setTimeout> | undefined} */
+    let timer;
+    const guard = new Promise((resolve) => {
+        timer = setTimeout(() => resolve(ASSISTANT_READ_TIMED_OUT), budget);
+        // Do not hold the event loop open purely for this guard.
+        if (typeof timer?.unref === 'function') timer.unref();
+    });
+    try {
+        return await Promise.race([
+            Promise.resolve(task).catch(() => ASSISTANT_READ_TIMED_OUT),
+            guard,
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+/**
+ * Resolve the effective per-read budget: the smaller of the remaining command
+ * deadline and the per-read ceiling. Returns 0 when the deadline has passed.
+ * @param {number} [remainingMs]
+ * @param {number} [ceilingMs]
+ * @returns {number}
+ */
+export function resolveAssistantReadBudgetMs(remainingMs, ceilingMs = ASSISTANT_READ_TIMEOUT_MS) {
+    const ceiling = Number.isFinite(Number(ceilingMs)) && Number(ceilingMs) > 0
+        ? Number(ceilingMs)
+        : ASSISTANT_READ_TIMEOUT_MS;
+    if (remainingMs == null) return ceiling;
+    const remaining = Number(remainingMs);
+    if (!Number.isFinite(remaining) || remaining <= 0) return 0;
+    return Math.min(ceiling, remaining);
+}
 
 /**
  * Browser-context helper. Keep this self-contained so Playwright can serialize
@@ -37,6 +98,41 @@ export function readTopLevelAssistantTexts(selectors) {
         if (texts.length) return texts;
     }
     return [];
+}
+
+/**
+ * Browser-context helper: count top-level assistant turns and serialize only the
+ * turns at/after `minIndex`. Long conversations otherwise pay `innerText` on
+ * every historical turn on every 500ms poll tick even though only the newest
+ * answer matters (#88). Keep self-contained for page.evaluate serialization.
+ * @param {{ selectors: string[], minIndex: number }} input
+ * @returns {{ total: number, texts: string[] }}
+ */
+export function readAssistantTextsAfterIndex(input) {
+    const activeSelectors = Array.isArray(input && input.selectors) && input.selectors.length
+        ? input.selectors
+        : [
+            '[data-message-author-role="assistant"]',
+            '[data-turn="assistant"]',
+            'article[data-testid^="conversation-turn"]',
+        ];
+    const rawMin = Number(input && input.minIndex);
+    const minIndex = Number.isFinite(rawMin) && rawMin > 0 ? Math.floor(rawMin) : 0;
+    const isInsideAnotherMatchedNode = (/** @type {any} */ el, /** @type {any[]} */ matched) =>
+        matched.some(other => other !== el && typeof other.contains === 'function' && other.contains(el));
+
+    for (const selector of activeSelectors) {
+        const matched = Array.from(document.querySelectorAll(selector));
+        const topLevel = matched.filter(el => !isInsideAnotherMatchedNode(el, matched));
+        if (!topLevel.length) continue;
+        // Read text only for the tail we actually need.
+        const texts = topLevel
+            .slice(minIndex)
+            .map(el => String((/** @type {any} */ (el)).innerText || el.textContent || '').trim())
+            .filter(Boolean);
+        return { total: topLevel.length, texts };
+    }
+    return { total: 0, texts: [] };
 }
 
 /**

--- a/web-ai/chatgpt-response-observer.mjs
+++ b/web-ai/chatgpt-response-observer.mjs
@@ -13,7 +13,10 @@
 import {
     CHATGPT_ASSISTANT_SELECTORS,
     CHATGPT_STOP_SELECTORS,
+    ASSISTANT_READ_TIMED_OUT,
     readTopLevelAssistantTexts,
+    resolveAssistantReadBudgetMs,
+    withAssistantReadTimeout,
 } from './chatgpt-response-dom.mjs';
 
 const DEFAULT_QUIET_MS = 1_200;
@@ -90,18 +93,22 @@ export async function observeAssistantResponse(page, { baselineAssistantCount = 
  * rejecting placeholders via the injected `isFinalAnswer` predicate. Read-only;
  * never throws. Returns `null` when there is no usable final answer.
  * @param {{ evaluate: Function, waitForTimeout?: Function, locator?: Function }} page
- * @param {{ baselineAssistantCount?: number, isFinalAnswer?: (text: string) => boolean, readStreaming?: () => Promise<boolean>|boolean, readFinished?: () => Promise<boolean>|boolean, stabilityWindowMs?: number }} [opts]
+ * @param {{ baselineAssistantCount?: number, isFinalAnswer?: (text: string) => boolean, readStreaming?: () => Promise<boolean>|boolean, readFinished?: () => Promise<boolean>|boolean, stabilityWindowMs?: number, readTimeoutMs?: number }} [opts]
  * @returns {Promise<{ from: 'recovery', text: string, recovered: true, streaming: boolean, finished: boolean, responseStableMs: number } | null>}
  */
-export async function recoverAssistantResponse(page, { baselineAssistantCount = 0, isFinalAnswer, readStreaming, readFinished, stabilityWindowMs } = {}) {
+export async function recoverAssistantResponse(page, { baselineAssistantCount = 0, isFinalAnswer, readStreaming, readFinished, stabilityWindowMs, readTimeoutMs } = {}) {
     const minIdx = Math.max(0, Math.floor(Number(baselineAssistantCount) || 0));
+    const readBudgetMs = resolveAssistantReadBudgetMs(readTimeoutMs);
     const readCandidates = async () => {
         let texts;
-        try {
-            texts = await page.evaluate(readTopLevelAssistantTexts, CHATGPT_ASSISTANT_SELECTORS);
-        } catch {
-            return [];
-        }
+        // Recovery runs right after a poll timeout, so an unbounded read here
+        // would re-hang the command it is supposed to rescue (#88).
+        const evaluated = await withAssistantReadTimeout(
+            Promise.resolve().then(() => page.evaluate(readTopLevelAssistantTexts, CHATGPT_ASSISTANT_SELECTORS)),
+            readBudgetMs,
+        );
+        if (evaluated === ASSISTANT_READ_TIMED_OUT) return [];
+        texts = evaluated;
         if (!Array.isArray(texts) || !texts.length) return [];
         return texts.slice(minIdx).filter(text => {
             if (!text) return false;

--- a/web-ai/chatgpt.mjs
+++ b/web-ai/chatgpt.mjs
@@ -54,8 +54,12 @@ import { buildTargetMismatchResult } from './session-target-guard.mjs';
 import {
     CHATGPT_ASSISTANT_SELECTORS,
     CHATGPT_STOP_SELECTORS,
+    ASSISTANT_READ_TIMED_OUT,
+    readAssistantTextsAfterIndex,
     readTopLevelAssistantTexts,
     readTopLevelAssistantTextsFromLocators,
+    resolveAssistantReadBudgetMs,
+    withAssistantReadTimeout,
 } from './chatgpt-response-dom.mjs';
 
 const CHATGPT_HOSTS = new Set(['chatgpt.com', 'chat.openai.com']);
@@ -363,6 +367,9 @@ export async function pollWebAi(deps, input = {}) {
     let stableText = '';
     let stableSince = 0;
     let lastHeartbeat = 0;
+    // Counts assistant-DOM reads that exceeded their budget, so a stalled read is
+    // reported distinctly from "provider is still streaming" (#88).
+    let domReadTimeouts = 0;
     // 33 short-circuit: a MutationObserver wakes the loop as soon as the response
     // settles (bounded so it self-disconnects). The poller stays AUTHORITATIVE —
     // it still reads + verifies every tick; this only reduces wait latency, so the
@@ -398,8 +405,32 @@ export async function pollWebAi(deps, input = {}) {
                 };
             }
         }
-        const answers = await readAssistantMessages(page);
-        const newAnswers = answers.slice(baseline.assistantCount).filter(isFinalAnswer);
+        // Bound every DOM read by the time actually left, so a stalled evaluate
+        // cannot hold the loop past `deadline` (#88).
+        const readBudgetMs = deadline - Date.now();
+        // Out of budget is the deadline itself, not a stalled read; leave the
+        // loop so the timeout path is not mislabeled as a DOM-read failure.
+        if (readBudgetMs <= 0) break;
+        const read = await readAssistantMessagesAfterBaseline(page, {
+            remainingMs: readBudgetMs,
+            minIndex: baseline.assistantCount,
+        });
+        if (read.timedOut) {
+            domReadTimeouts += 1;
+            // Keep emitting liveness while reads stall. Silence here was the
+            // original symptom: the process looked alive with no output (#88).
+            const stalledAt = Date.now();
+            if (stalledAt - lastHeartbeat >= 30_000) {
+                const elapsed = Math.round((stalledAt - startedAt) / 1000);
+                process.stderr.write(`[poll] ${elapsed}s — assistant DOM read timed out (${domReadTimeouts}x); retrying...\n`);
+                lastHeartbeat = stalledAt;
+            }
+            // Re-check the outer deadline immediately instead of blocking here.
+            if (Date.now() > deadline) break;
+            await page.waitForTimeout(500).catch(() => undefined);
+            continue;
+        }
+        const newAnswers = read.newAnswers.filter(isFinalAnswer);
         const latest = newAnswers.at(-1) || '';
         const streaming = await isStreaming(page);
         const now = Date.now();
@@ -559,6 +590,10 @@ export async function pollWebAi(deps, input = {}) {
             isFinalAnswer,
             readStreaming: () => isStreaming(page),
             readFinished: () => isResponseFinished(page),
+            // Reads were already stalling during the poll; keep the rescue read
+            // short so recovery cannot extend the command by another full
+            // per-read ceiling (#88).
+            ...(domReadTimeouts > 0 ? { readTimeoutMs: 2_000 } : {}),
         });
         if (recovered?.text) {
             if (recovered.streaming === true) {
@@ -683,7 +718,9 @@ export async function pollWebAi(deps, input = {}) {
         ...(timedOutSession?.deadlineAt ? { deadlineAt: timedOutSession.deadlineAt } : {}),
         ...(timedOutSession?.conversationUrl ? { conversationUrl: timedOutSession.conversationUrl } : {}),
         baseline,
-        warnings: [],
+        // Distinguish "provider never finished" from "we could not read the DOM
+        // in time"; the two need different operator responses (#88).
+        warnings: domReadTimeouts > 0 ? [`assistant-dom-read-timeout:${domReadTimeouts}`] : [],
         usedFallbacks: [],
         recoverable: true,
         retryHint: 'poll-or-resume',
@@ -1002,9 +1039,10 @@ function persistResolverTraceForSession(session, traceCtx) {
 
 /**
  * @param {any} page
+ * @param {number} [remainingMs]
  */
-async function countAssistantMessages(page) {
-    return (await readAssistantMessages(page)).length;
+async function countAssistantMessages(page, remainingMs) {
+    return (await readAssistantMessages(page, { remainingMs })).length;
 }
 
 /**
@@ -1016,7 +1054,7 @@ async function waitForStableAssistantCount(page, timeoutMs = 8_000) {
     let previous = -1;
     let stableReads = 0;
     while (Date.now() < deadline) {
-        const count = await countAssistantMessages(page).catch(() => 0);
+        const count = await countAssistantMessages(page, deadline - Date.now()).catch(() => 0);
         if (count === previous) stableReads += 1;
         else stableReads = 0;
         previous = count;
@@ -1026,13 +1064,87 @@ async function waitForStableAssistantCount(page, timeoutMs = 8_000) {
 }
 
 /**
+ * Read top-level assistant turns, bounded by the caller's remaining deadline.
+ *
+ * Playwright's `page.evaluate()` has no timeout option, so an evaluation that
+ * stalls (huge conversation, blocked main thread) used to suspend the poll loop
+ * indefinitely — the outer deadline was only re-checked at the loop boundary
+ * (#88). Every read is now raced against the remaining budget, and a read that
+ * exceeds it reports `timedOut` instead of parking the command.
+ *
  * @param {any} page
+ * @param {{ remainingMs?: number, minIndex?: number }} [options]
+ * @returns {Promise<string[] & { timedOut?: boolean, total?: number }>}
  */
-async function readAssistantMessages(page) {
-    const evaluated = await page.evaluate(readTopLevelAssistantTexts, ASSISTANT_SELECTORS).catch(() => []);
+async function readAssistantMessages(page, options = {}) {
+    const budgetMs = resolveAssistantReadBudgetMs(options.remainingMs);
+    if (budgetMs <= 0) return markTimedOut([]);
+    const evaluated = await withAssistantReadTimeout(
+        Promise.resolve().then(() => page.evaluate(readTopLevelAssistantTexts, ASSISTANT_SELECTORS)),
+        budgetMs,
+    );
+    if (evaluated === ASSISTANT_READ_TIMED_OUT) return markTimedOut([]);
     if (Array.isArray(evaluated) && evaluated.length) return evaluated.map(cleanAssistantText).filter(Boolean);
-    const fallback = await readTopLevelAssistantTextsFromLocators(page, ASSISTANT_SELECTORS);
+    // The locator fallback issues one round trip per turn, so bound it by the
+    // budget that is actually left after the evaluate attempt.
+    const fallback = await withAssistantReadTimeout(
+        Promise.resolve().then(() => readTopLevelAssistantTextsFromLocators(page, ASSISTANT_SELECTORS)),
+        resolveAssistantReadBudgetMs(options.remainingMs),
+    );
+    if (fallback === ASSISTANT_READ_TIMED_OUT) return markTimedOut([]);
     return fallback.map(cleanAssistantText).filter(Boolean);
+}
+
+/**
+ * Poll-tick read: count all turns in-page but serialize only the turns after the
+ * baseline. Avoids re-serializing the whole conversation every 500ms (#88).
+ * Falls back to the full read when the trimmed path is unavailable or times out.
+ * @param {any} page
+ * @param {{ remainingMs?: number, minIndex?: number }} options
+ * @returns {Promise<{ newAnswers: string[], total: number, timedOut: boolean }>}
+ */
+async function readAssistantMessagesAfterBaseline(page, options = {}) {
+    const minIndex = Math.max(0, Math.floor(Number(options.minIndex) || 0));
+    const budgetMs = resolveAssistantReadBudgetMs(options.remainingMs);
+    if (budgetMs <= 0) return { newAnswers: [], total: 0, timedOut: true };
+    const trimmed = await withAssistantReadTimeout(
+        Promise.resolve().then(() => page.evaluate(readAssistantTextsAfterIndex, {
+            selectors: ASSISTANT_SELECTORS,
+            minIndex,
+        })),
+        budgetMs,
+    );
+    if (trimmed === ASSISTANT_READ_TIMED_OUT) return { newAnswers: [], total: 0, timedOut: true };
+    // Only trust the trimmed shape when it actually observed turns. A page that
+    // cannot serialize the object argument (older stubs, restricted contexts)
+    // reports zero turns; fall back to the full read so behavior is unchanged.
+    if (trimmed && typeof trimmed === 'object' && Array.isArray((/** @type {any} */ (trimmed)).texts)
+        && Number((/** @type {any} */ (trimmed)).total) > 0) {
+        const result = /** @type {{ total: number, texts: string[] }} */ (trimmed);
+        return {
+            newAnswers: result.texts.map(cleanAssistantText).filter(Boolean),
+            total: Number(result.total) || 0,
+            timedOut: false,
+        };
+    }
+    // No turns observed through the trimmed path (or a legacy array shape came
+    // back): reuse the full read, which also covers the locator fallback.
+    const answers = await readAssistantMessages(page, { remainingMs: options.remainingMs });
+    return {
+        newAnswers: answers.slice(minIndex),
+        total: answers.length,
+        timedOut: answers.timedOut === true,
+    };
+}
+
+/**
+ * Tag an assistant read as deadline-exceeded while keeping the array shape all
+ * existing callers expect.
+ * @param {string[]} texts
+ * @returns {string[] & { timedOut?: boolean }}
+ */
+function markTimedOut(texts) {
+    return Object.assign(texts, { timedOut: true });
 }
 
 /**


### PR DESCRIPTION
Fixes #88

## Problem

ChatGPT polling could stay alive with no progress well past `--timeout`.

`pollWebAi` checks its deadline only at the `while` boundary, then awaits:

```js
const answers = await readAssistantMessages(page);
```

which calls:

```js
await page.evaluate(readTopLevelAssistantTexts, ASSISTANT_SELECTORS)
```

Playwright's `page.evaluate()` accepts no timeout option (only `locator.evaluate` takes one). So when assistant-message extraction stalled on a very large conversation, control never reached the next deadline check. The process and the session lock stayed alive while the stderr heartbeat went silent, which matches the reported symptom: `sessions doctor` reported a valid target, a healthy command-lock heartbeat, and no CDP or login failure.

The same function also read and cleaned every top-level assistant message on each 500 ms tick, then sliced off everything before `baseline.assistantCount` — so long conversations paid `innerText` on the whole history to obtain one new answer.

## Changes

- add `withAssistantReadTimeout()` and `resolveAssistantReadBudgetMs()` in `chatgpt-response-dom.mjs`; each assistant read is raced against the smaller of the remaining command deadline and a per-read ceiling
- bound the `page.evaluate()` path, the locator fallback, and the post-timeout recovery read in `chatgpt-response-observer.mjs`, which otherwise re-hung the command it exists to rescue
- add `readAssistantTextsAfterIndex()`: count turns in-page but serialize only the turns at/after the baseline
- keep emitting the poll heartbeat while reads stall, since silence with a live process was the original symptom
- surface `assistant-dom-read-timeout:<n>` on the timeout envelope so a stalled DOM read is distinguishable from provider generation still streaming

## Behavior

A read that exceeds its budget retries on the next tick; at the deadline the existing recoverable `provider.poll-timeout` envelope is returned, so `poll` and `sessions resume` semantics are unchanged.

Two details worth reviewing:

- Exhausting the budget exactly at the loop boundary is treated as the deadline itself, not as a DOM-read failure, so ordinary timeouts are not mislabeled as stalls.
- When reads were already stalling, the post-timeout recovery read uses a shorter budget so recovery cannot extend the command by another full ceiling.

The trimmed read falls back to the existing full read whenever it observes no turns, which keeps pages that cannot serialize the object argument on the previous behavior.

## Tests

New `test/unit/web-ai-assistant-read-deadline.test.mjs` reproduces the defect deterministically without ChatGPT, as suggested in the issue: it drives `pollWebAi` with a `page.evaluate()` that never resolves and asserts the command still honors its own deadline, returns the recoverable timeout envelope, and reports the stall.

It also covers the budget helpers (clamping, rejected reads, sentinel) and proves via getter instrumentation that historical turns are no longer re-serialized.

I verified the test actually catches the bug: with the bound removed, that poll test hangs until the runner's own timeout instead of passing.

One existing fake page in `web-ai-provider-session.test.mjs` keyed its answer sequence off a raw `evaluate` call count, so it was updated to key off the assistant-read argument shape instead. The assertions are unchanged.

## Verification

```
npx vitest run test/unit test/integration   # 1438 passed, 5 skipped
npm run typecheck                            # clean
npm run check:strict-baseline                # OK
bash structure/verify-counts.sh              # 76 passed (str_func.md refreshed via fix:counts)
```

`test/integration/post-action-smoke.test.mjs` and `self-heal-smoke.test.mjs` fail in my environment before this change as well, because no Chromium is installed locally; they are unrelated to this diff.

I have not reproduced the fix against a live 40–60 KB multi-turn ChatGPT conversation, so the real-world stall threshold is still unverified; the deadline behavior itself is covered deterministically.
